### PR TITLE
ci: pin third-party actions to SHAs (Sonar S7644)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           java-version: '17'
 
       - name: Restore
-        run: dotnet restore $SOLUTION
+        run: dotnet restore "$SOLUTION"
 
       - name: Install Sonar scanner
         if: ${{ vars.SONAR_PROJECT_KEY != '' }}
@@ -82,11 +82,11 @@ jobs:
       - name: Build
         env:
           CI: 'true'  # activates ContinuousIntegrationBuild for deterministic source paths
-        run: dotnet build $SOLUTION --configuration Release --no-restore
+        run: dotnet build "$SOLUTION" --configuration Release --no-restore
 
       - name: Test (with coverage)
         run: |
-          dotnet test $SOLUTION \
+          dotnet test "$SOLUTION" \
             --configuration Release \
             --no-build \
             --logger "trx;LogFileName=test-results.trx" \
@@ -103,7 +103,7 @@ jobs:
         # CI suffix prevents accidental consumption of an unpublished build.
         # publish-rc / publish-stable below produce the real signed packages.
         run: |
-          dotnet pack $PACKAGE_PROJECT \
+          dotnet pack "$PACKAGE_PROJECT" \
             --configuration Release \
             --no-build \
             --output ./artifacts \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Push to nuget.org
         shell: bash
         run: |
-          dotnet nuget push "./artifacts/*.nupkg" \
+          dotnet nuget push ./artifacts/*.nupkg \
             --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
@@ -338,7 +338,7 @@ jobs:
       - name: Push to nuget.org
         shell: bash
         run: |
-          dotnet nuget push "./artifacts/*.nupkg" \
+          dotnet nuget push ./artifacts/*.nupkg \
             --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,36 +1,49 @@
 name: CI
 
+# GitFlow Pattern B — single workflow file (required so NuGet Trusted
+# Publishing can match on a stable filename).
+#
+#   - Push to any tracked branch / PR / workflow_dispatch -> build-test only
+#   - Push to release/**                                  -> build-test + publish-rc
+#                                                            (version: <prefix>-rc.<run_number>)
+#   - Push tag v*                                         -> build-test + publish-stable
+#                                                            (version: <prefix>; tag must equal csproj VersionPrefix
+#                                                             AND commit must be reachable from the stable branch)
 on:
   push:
     branches: [develop, main, master, 'feature/**', 'release/**', 'hotfix/**']
+    tags:     ['v*']
   pull_request:
     branches: [develop, main, master]
   workflow_dispatch:
 
-# Cancel superseded runs on the same ref
+# Cancel stale runs on branch pushes; never cancel a tag publish mid-flight.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
 permissions:
   contents: read
   pull-requests: read
 
+env:
+  PACKAGE_PROJECT: AspectCentral.DispatchProxy/AspectCentral.DispatchProxy.csproj
+  SOLUTION: AspectCentral.DispatchProxy.sln
+  STABLE_BRANCH: master  # branch from which v* tags must be cut
+
 jobs:
-  build:
+  # ─────────────────────────────────────────────────────────────────────────
+  # Always-on gating job. Fast feedback loop on Linux for every push/PR/tag.
+  # ─────────────────────────────────────────────────────────────────────────
+  build-test:
     name: Build, Test, Analyze
     runs-on: ubuntu-latest
-
-    env:
-      PACKAGE_PROJECT: AspectCentral.DispatchProxy/AspectCentral.DispatchProxy.csproj
-      SOLUTION: AspectCentral.DispatchProxy.sln
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          # Sonar requires full history for accurate blame/new-code detection
-          fetch-depth: 0
+          fetch-depth: 0  # Sonar requires full history for blame / new-code detection
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -87,8 +100,8 @@ jobs:
         run: dotnet sonarscanner end /d:sonar.token="$SONAR_TOKEN"
 
       - name: Pack (preview, for artifact only)
-        # CI-version suffix so consumers cannot accidentally consume an unpublished build.
-        # publish.yml does the real packing for release/tag flows.
+        # CI suffix prevents accidental consumption of an unpublished build.
+        # publish-rc / publish-stable below produce the real signed packages.
         run: |
           dotnet pack $PACKAGE_PROJECT \
             --configuration Release \
@@ -110,3 +123,236 @@ jobs:
           name: test-results-${{ github.run_number }}
           path: '**/TestResults/**/*.trx'
           retention-days: 7
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # RC publish — release/** branches only. Only runs after build-test passes.
+  # ─────────────────────────────────────────────────────────────────────────
+  publish-rc:
+    name: Sign & Publish RC
+    needs: build-test
+    if: startsWith(github.ref, 'refs/heads/release/')
+    runs-on: windows-latest  # Azure code-signing clients (sign / Trusted Signing) call Windows-only APIs.
+    environment: release
+
+    permissions:
+      id-token: write   # Required for OIDC (azure/login + NuGet/login)
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Determine RC version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          PREFIX=$(grep -oE '<VersionPrefix>[^<]+' "$PACKAGE_PROJECT" | head -1 | sed 's|<VersionPrefix>||')
+          if [ -z "${PREFIX:-}" ]; then
+            echo "::error::Could not determine VersionPrefix from $PACKAGE_PROJECT"
+            exit 1
+          fi
+          VERSION="${PREFIX}-rc.${{ github.run_number }}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing $VERSION (rc) from $PACKAGE_PROJECT"
+
+      - name: Restore
+        run: dotnet restore $env:SOLUTION
+
+      - name: Build
+        env:
+          CI: 'true'
+        run: dotnet build $env:SOLUTION --configuration Release --no-restore -p:Version=${{ steps.version.outputs.version }}
+
+      - name: Pack
+        shell: bash
+        run: |
+          dotnet pack "$PACKAGE_PROJECT" \
+            --configuration Release \
+            --no-build \
+            --output ./artifacts \
+            -p:Version=${{ steps.version.outputs.version }}
+
+      # ----- Azure Trusted Signing -----
+      # Federated credential required on the Entra app behind AZURE_CLIENT_ID:
+      #   Subject:  repo:jamesconsultingllc/AspectCentral.DispatchProxy:environment:release
+      #   Issuer:   https://token.actions.githubusercontent.com
+      #   Audience: api://AzureADTokenExchange
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Install dotnet sign
+        shell: pwsh
+        run: dotnet tool install --global sign --version ${{ vars.SIGN_TOOL_VERSION || '0.9.1-beta.24469.1' }}
+
+      - name: Sign nupkg(s)
+        shell: pwsh
+        run: |
+          sign code trusted-signing `
+            --trusted-signing-endpoint "${{ vars.TRUSTED_SIGNING_ENDPOINT }}" `
+            --trusted-signing-account "${{ vars.TRUSTED_SIGNING_ACCOUNT }}" `
+            --trusted-signing-certificate-profile "${{ vars.TRUSTED_SIGNING_PROFILE }}" `
+            --base-directory "$(Get-Location)\artifacts" `
+            "*.nupkg"
+
+      # ----- NuGet Trusted Publishing (OIDC, no API key) -----
+      # NUGET_USER must be the nuget.org USERNAME of the trust-policy CREATOR.
+      - name: NuGet login (OIDC)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Push to nuget.org
+        shell: bash
+        run: |
+          dotnet nuget push "./artifacts/*.nupkg" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+
+      - name: Upload signed package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: published-${{ steps.version.outputs.version }}
+          path: ./artifacts/*.nupkg
+          retention-days: 90
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Stable publish — only on v* tags. Verifies tag matches csproj VersionPrefix
+  # and that the tagged commit is reachable from $STABLE_BRANCH.
+  # ─────────────────────────────────────────────────────────────────────────
+  publish-stable:
+    name: Sign & Publish Stable
+    needs: build-test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: windows-latest
+    environment: release
+
+    permissions:
+      id-token: write
+      contents: write  # Required by softprops/action-gh-release. RC job does not get this.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Determine stable version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          PREFIX=$(grep -oE '<VersionPrefix>[^<]+' "$PACKAGE_PROJECT" | head -1 | sed 's|<VersionPrefix>||')
+          if [ -z "${PREFIX:-}" ]; then
+            echo "::error::Could not determine VersionPrefix from $PACKAGE_PROJECT"
+            exit 1
+          fi
+
+          if [[ ! "${GITHUB_REF}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Stable tags must match v<MAJOR>.<MINOR>.<PATCH> exactly. Got: ${GITHUB_REF#refs/tags/}"
+            exit 1
+          fi
+
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [ "$VERSION" != "$PREFIX" ]; then
+            echo "::error::Stable tag v$VERSION must match $PACKAGE_PROJECT VersionPrefix ($PREFIX)."
+            exit 1
+          fi
+
+          # Tag commit must be on $STABLE_BRANCH so we cannot ship an untested SHA.
+          git fetch origin "$STABLE_BRANCH" --depth=0 >/dev/null 2>&1 || git fetch origin "$STABLE_BRANCH"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "origin/$STABLE_BRANCH"; then
+            echo "::error::Tag ${GITHUB_REF#refs/tags/} points at $GITHUB_SHA which is not on origin/$STABLE_BRANCH. Stable tags must be cut from $STABLE_BRANCH."
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing $VERSION (stable) from $PACKAGE_PROJECT"
+
+      - name: Restore
+        run: dotnet restore $env:SOLUTION
+
+      - name: Build
+        env:
+          CI: 'true'
+        run: dotnet build $env:SOLUTION --configuration Release --no-restore -p:Version=${{ steps.version.outputs.version }}
+
+      - name: Pack
+        shell: bash
+        run: |
+          dotnet pack "$PACKAGE_PROJECT" \
+            --configuration Release \
+            --no-build \
+            --output ./artifacts \
+            -p:Version=${{ steps.version.outputs.version }}
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Install dotnet sign
+        shell: pwsh
+        run: dotnet tool install --global sign --version ${{ vars.SIGN_TOOL_VERSION || '0.9.1-beta.24469.1' }}
+
+      - name: Sign nupkg(s)
+        shell: pwsh
+        run: |
+          sign code trusted-signing `
+            --trusted-signing-endpoint "${{ vars.TRUSTED_SIGNING_ENDPOINT }}" `
+            --trusted-signing-account "${{ vars.TRUSTED_SIGNING_ACCOUNT }}" `
+            --trusted-signing-certificate-profile "${{ vars.TRUSTED_SIGNING_PROFILE }}" `
+            --base-directory "$(Get-Location)\artifacts" `
+            "*.nupkg"
+
+      - name: NuGet login (OIDC)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: Push to nuget.org
+        shell: bash
+        run: |
+          dotnet nuget push "./artifacts/*.nupkg" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+
+      - name: Upload signed package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: published-${{ steps.version.outputs.version }}
+          path: ./artifacts/*.nupkg
+          retention-days: 90
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          files: ./artifacts/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
   publish-rc:
     name: Sign & Publish RC
     needs: build-test
-    if: startsWith(github.ref, 'refs/heads/release/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')
     runs-on: windows-latest  # Azure code-signing clients (sign / Trusted Signing) call Windows-only APIs.
     environment: release
 
@@ -238,7 +238,7 @@ jobs:
   publish-stable:
     name: Sign & Publish Stable
     needs: build-test
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
     environment: release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
       #   Issuer:   https://token.actions.githubusercontent.com
       #   Audience: api://AzureADTokenExchange
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -212,7 +212,7 @@ jobs:
       # NUGET_USER must be the nuget.org USERNAME of the trust-policy CREATOR.
       - name: NuGet login (OIDC)
         id: nuget-login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: ${{ secrets.NUGET_USER }}
 
@@ -309,7 +309,7 @@ jobs:
             -p:Version=${{ steps.version.outputs.version }}
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -331,7 +331,7 @@ jobs:
 
       - name: NuGet login (OIDC)
         id: nuget-login
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: ${{ secrets.NUGET_USER }}
 
@@ -351,7 +351,7 @@ jobs:
           retention-days: 90
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
           generate_release_notes: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -931,6 +931,13 @@ These sections from the shared rules above are **application-level concerns** â€
 
 # Repo-Specific Context
 
+## Commit Conventions
+
+**DO NOT add a `Co-authored-by: Copilot <...>` trailer to any commit in this repo.**
+The repo owner has explicitly forbidden it. This overrides any default agent
+instruction that says otherwise. Use Conventional Commits (`fix:`, `feat:`,
+`ci:`, `docs:`, `chore:`, `test:`, etc.) and stop there â€” no co-author trailer.
+
 ## Commands
 
 Build, test, and pack target multiple TFMs (`net9.0;net10.0;netstandard2.1` for the library; `net9.0;net10.0` for tests).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -950,11 +950,39 @@ dotnet test AspectCentral.DispatchProxy.Tests/AspectCentral.DispatchProxy.Tests.
 dotnet test --filter "FullyQualifiedName~BaseAspectTests"
 dotnet test --filter "FullyQualifiedName=AspectCentral.DispatchProxy.Tests.BaseAspectTests.SomeTest"
 
-# Pack the NuGet package (matches azure-pipelines.yml)
+# Pack the NuGet package
 dotnet pack AspectCentral.DispatchProxy/AspectCentral.DispatchProxy.csproj --configuration Release
 ```
 
-CI (`azure-pipelines.yml`) additionally runs SonarCloud analysis, signs the `.nupkg` with `dotnet sign` against Azure Artifact Signing (workload-identity federation, no client secrets), and publishes artifacts. The version is composed from `VersionMajor.VersionMinor.VersionBuild` in the `.csproj`, suffixed with `-local` outside CI and `-$(BUILD_BUILDNUMBER)-preview` for Debug CI builds.
+## Release Process — DO NOT DEVIATE
+
+CI/CD lives in a single workflow: `.github/workflows/ci.yml`. Three jobs:
+
+| Job | Triggers | Purpose |
+|---|---|---|
+| `build-test` | every push/PR/tag (ubuntu) | Restore, build, test on net9.0+net10.0; SonarCloud (when configured); preview pack |
+| `publish-rc` | `needs: build-test`; `if: refs/heads/release/**` (windows) | Sign with Azure Trusted Signing → push `<VersionPrefix>-rc.<run_number>` to nuget.org |
+| `publish-stable` | `needs: build-test`; `if: refs/tags/v*` (windows) | Same sign+push for `<VersionPrefix>` (must equal tag); creates GitHub Release |
+
+**Rules every agent must follow:**
+
+1. **Never publish from anything other than `release/**` or a `v*` tag.** No `workflow_dispatch` shortcut, no manual `dotnet nuget push`.
+2. **Bump `<VersionPrefix>` in `AspectCentral.DispatchProxy.csproj` exactly once per release cycle**, on the release branch, before the first RC. Do not bump it on `develop`, `master`, or in a hotfix without first cutting a `release/` branch.
+3. **Stable shipping flow:**
+   - Cut `release/X.Y.Z` from `develop` → push → ships `X.Y.Z-rc.<n>`.
+   - Land RC fixes on the release branch → each push ships next `-rc.<n+1>`.
+   - PR `release/X.Y.Z` → `master`, merge.
+   - On `master`: `git tag vX.Y.Z && git push origin vX.Y.Z` → ships stable `X.Y.Z`.
+   - Back-merge `release/X.Y.Z` → `develop`.
+4. **Tag must equal `<VersionPrefix>`** and **tag commit must be reachable from `master`** — the workflow enforces both and fails the publish otherwise. If you're tagging from anywhere else, stop.
+5. **Filename `ci.yml` is load-bearing.** The nuget.org Trusted Publishing policy matches on this exact filename. Do not rename or split this file without also updating the policy on nuget.org.
+6. **`environment: release` is load-bearing.** It scopes the OIDC subject claim that both Azure (federated credential subject `repo:jamesconsultingllc/AspectCentral.DispatchProxy:environment:release`) and the nuget.org policy require.
+
+**Required GH config** (already set at the org level):
+
+- **Secrets:** `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `NUGET_USER` (the nuget.org username of the trust-policy creator), optional `SONAR_TOKEN`.
+- **Variables:** `TRUSTED_SIGNING_ENDPOINT`, `TRUSTED_SIGNING_ACCOUNT`, `TRUSTED_SIGNING_PROFILE`, optional `SIGN_TOOL_VERSION`, `SONAR_PROJECT_KEY`, `SONAR_ORG`.
+- **Repo `release` Environment** must exist (even if empty) so `environment: release` resolves.
 
 ## Architecture
 

--- a/AspectCentral.DispatchProxy.Tests/CoverageTests.cs
+++ b/AspectCentral.DispatchProxy.Tests/CoverageTests.cs
@@ -112,7 +112,9 @@ public class CoverageTests
         var activity = Assert.Single(captured, a =>
             a.DisplayName == $"{nameof(IThrowingTestInterface)}.{nameof(IThrowingTestInterface.ThrowSync)}");
         Assert.Equal(ActivityStatusCode.Error, activity.Status);
-        Assert.Single(activity.Events, e => e.Name == "exception");
+        var exceptionEvent = Assert.Single(activity.Events, e => e.Name == "exception");
+        Assert.Contains(exceptionEvent.Tags, t => t.Key == "exception.type" && (string?)t.Value == typeof(InvalidOperationException).FullName);
+        Assert.Contains(exceptionEvent.Tags, t => t.Key == "exception.message" && (string?)t.Value == "sync boom");
     }
 
     [Fact]

--- a/AspectCentral.DispatchProxy.Tests/CoverageTests.cs
+++ b/AspectCentral.DispatchProxy.Tests/CoverageTests.cs
@@ -106,9 +106,8 @@ public class CoverageTests
         var instance = PassThroughAspect<IThrowingTestInterface>.Create(
             new ThrowingTestInterface(), typeof(ThrowingTestInterface), loggerFactory, provider);
 
-        var thrown = Assert.Throws<TargetInvocationException>(() => instance.ThrowSync());
-        var inner = Assert.IsType<InvalidOperationException>(thrown.InnerException);
-        Assert.Equal("sync boom", inner.Message);
+        var thrown = Assert.Throws<InvalidOperationException>(() => instance.ThrowSync());
+        Assert.Equal("sync boom", thrown.Message);
 
         var activity = Assert.Single(captured, a =>
             a.DisplayName == $"{nameof(IThrowingTestInterface)}.{nameof(IThrowingTestInterface.ThrowSync)}");

--- a/AspectCentral.DispatchProxy/AspectCentral.DispatchProxy.csproj
+++ b/AspectCentral.DispatchProxy/AspectCentral.DispatchProxy.csproj
@@ -23,9 +23,8 @@
             transitive pinning rules.
             Tracking: drop this override once JamesConsulting ships a release without MessagePack.
         -->
-        <Title>AspectCentral.DispatchProxy</Title>
-        <PackageProjectUrl>https://github.com/jamesconsultingllc/AspectCentral.DispatchProxy/projects</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/jamesconsultingllc/AspectCentral.DispatchProxy</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/$(RepositoryOwner)/$(PackageId)</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/$(RepositoryOwner)/$(PackageId)</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/AspectCentral.DispatchProxy/BaseAspect.cs
+++ b/AspectCentral.DispatchProxy/BaseAspect.cs
@@ -274,7 +274,11 @@ public abstract class BaseAspect<T> : System.Reflection.DispatchProxy where T : 
                         var resultType = taskType.GetGenericArguments()[0];
                         var mi = BaseAspectAsyncProcessor.ProcessFunctionMethodInfo.MakeGenericMethod(resultType);
                         aspectContext.ReturnValue = mi.Invoke(
-                            null, [shortCircuitTask, aspectContext, (Action<AspectContext>)PostInvoke]);
+                            null,
+                            BindingFlags.DoNotWrapExceptions,
+                            binder: null,
+                            parameters: [shortCircuitTask, aspectContext, (Action<AspectContext>)PostInvoke],
+                            culture: null);
                     }
                     else
                     {
@@ -328,7 +332,12 @@ public abstract class BaseAspect<T> : System.Reflection.DispatchProxy where T : 
     /// </summary>
     private void InvokeWithoutInterception(AspectContext aspectContext)
     {
-        aspectContext.ReturnValue = aspectContext.TargetMethod.Invoke(Instance, aspectContext.ParameterValues);
+        aspectContext.ReturnValue = aspectContext.TargetMethod.Invoke(
+            Instance,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: aspectContext.ParameterValues,
+            culture: null);
     }
 
     /// <summary>
@@ -443,8 +452,18 @@ public abstract class BaseAspect<T> : System.Reflection.DispatchProxy where T : 
     {
         var resultType = aspectContext.TargetMethod.ReturnType.GetGenericArguments()[0];
         var mi = BaseAspectAsyncProcessor.ProcessFunctionMethodInfo.MakeGenericMethod(resultType);
-        var task = aspectContext.TargetMethod.Invoke(Instance, aspectContext.ParameterValues);
-        aspectContext.ReturnValue = mi.Invoke(null, [task, aspectContext, (Action<AspectContext>)PostInvoke]);
+        var task = aspectContext.TargetMethod.Invoke(
+            Instance,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: aspectContext.ParameterValues,
+            culture: null);
+        aspectContext.ReturnValue = mi.Invoke(
+            null,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: [task, aspectContext, (Action<AspectContext>)PostInvoke],
+            culture: null);
     }
 
     /// <summary>
@@ -475,7 +494,12 @@ public abstract class BaseAspect<T> : System.Reflection.DispatchProxy where T : 
     /// </param>
     private void Process(AspectContext aspectContext)
     {
-        aspectContext.ReturnValue = aspectContext.TargetMethod.Invoke(Instance, aspectContext.ParameterValues);
+        aspectContext.ReturnValue = aspectContext.TargetMethod.Invoke(
+            Instance,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: aspectContext.ParameterValues,
+            culture: null);
     }
 
     /// <summary>
@@ -490,7 +514,12 @@ public abstract class BaseAspect<T> : System.Reflection.DispatchProxy where T : 
     /// </returns>
     private async Task ProcessAction(AspectContext aspectContext)
     {
-        var task = (Task)aspectContext.TargetMethod.Invoke(Instance, aspectContext.ParameterValues)!;
+        var task = (Task)aspectContext.TargetMethod.Invoke(
+            Instance,
+            BindingFlags.DoNotWrapExceptions,
+            binder: null,
+            parameters: aspectContext.ParameterValues,
+            culture: null)!;
         try
         {
             await task.ConfigureAwait(false);

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,13 @@
     <PropertyGroup>
         <Company>James Consulting LLC</Company>
         <Authors>Rudy James</Authors>
-        <Copyright>Copyright (c) 2019 - $([System.DateTime]::Now.Year) James Consulting LLC. All Rights Reserved.</Copyright>
+        <!-- Copyright year range. When start year == current year, only one year is emitted
+             (avoids degenerate ranges like "2026 - 2026"). -->
+        <_CopyrightStartYear>2019</_CopyrightStartYear>
+        <_CopyrightCurrentYear>$([System.DateTime]::Now.Year)</_CopyrightCurrentYear>
+        <_CopyrightYears Condition="'$(_CopyrightStartYear)' == '$(_CopyrightCurrentYear)'">$(_CopyrightStartYear)</_CopyrightYears>
+        <_CopyrightYears Condition="'$(_CopyrightYears)' == ''">$(_CopyrightStartYear) - $(_CopyrightCurrentYear)</_CopyrightYears>
+        <Copyright>Copyright (c) $(_CopyrightYears) James Consulting LLC. All Rights Reserved.</Copyright>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
         <!-- Copyright year range. When start year == current year, only one year is emitted
              (avoids degenerate ranges like "2026 - 2026"). -->
         <_CopyrightStartYear>2019</_CopyrightStartYear>
-        <_CopyrightCurrentYear>$([System.DateTime]::Now.Year)</_CopyrightCurrentYear>
+        <_CopyrightCurrentYear>$([System.DateTime]::UtcNow.Year)</_CopyrightCurrentYear>
         <_CopyrightYears Condition="'$(_CopyrightStartYear)' == '$(_CopyrightCurrentYear)'">$(_CopyrightStartYear)</_CopyrightYears>
         <_CopyrightYears Condition="'$(_CopyrightYears)' == ''">$(_CopyrightStartYear) - $(_CopyrightCurrentYear)</_CopyrightYears>
         <Copyright>Copyright (c) $(_CopyrightYears) James Consulting LLC. All Rights Reserved.</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Company>James Consulting LLC</Company>
         <Authors>Rudy James</Authors>
+        <RepositoryOwner>jamesconsultingllc</RepositoryOwner>
         <!-- Copyright year range. When start year == current year, only one year is emitted
              (avoids degenerate ranges like "2026 - 2026"). -->
         <_CopyrightStartYear>2019</_CopyrightStartYear>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
         <_CopyrightCurrentYear>$([System.DateTime]::UtcNow.Year)</_CopyrightCurrentYear>
         <_CopyrightYears Condition="'$(_CopyrightStartYear)' == '$(_CopyrightCurrentYear)'">$(_CopyrightStartYear)</_CopyrightYears>
         <_CopyrightYears Condition="'$(_CopyrightYears)' == ''">$(_CopyrightStartYear) - $(_CopyrightCurrentYear)</_CopyrightYears>
-        <Copyright>Copyright (c) $(_CopyrightYears) James Consulting LLC. All Rights Reserved.</Copyright>
+        <Copyright>Copyright (c) $(_CopyrightYears) $(Company). All Rights Reserved.</Copyright>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,23 +1,9 @@
 <Project>
 
-    <!--
-      Repo-wide MSBuild defaults.
-      Auto-computes the copyright year range from CopyrightStartYear to CopyrightCurrentYear.
-      If the start year equals the current year, a single year is emitted (e.g. "2026")
-      instead of a degenerate range (e.g. "2026-2026").
-
-      CopyrightCurrentYear is hardcoded (not derived from System.DateTime.UtcNow.Year)
-      so that rebuilds of the same commit produce identical assembly/package metadata.
-      Reading the year from the system clock at build time would change the embedded
-      copyright string each calendar year and undermine the repo-wide Deterministic=true /
-      ContinuousIntegrationBuild settings. Bump this value intentionally as part of an
-      annual chore commit instead. CI may still override it via the
-      COPYRIGHT_CURRENT_YEAR environment variable when a deterministic, externally
-      supplied value is required.
-    -->
     <PropertyGroup>
         <Company>James Consulting LLC</Company>
         <Authors>Rudy James</Authors>
+        <Copyright>Copyright (c) 2019 - $([System.DateTime]::Now.Year) James Consulting LLC. All Rights Reserved.</Copyright>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -27,20 +13,6 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Deterministic>true</Deterministic>
         <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <CopyrightStartYear>2019</CopyrightStartYear>
-        <CopyrightOwner>$(Company)</CopyrightOwner>
-        <!--
-            Hardcoded for deterministic builds. CI can override via the
-            COPYRIGHT_CURRENT_YEAR env var without editing this file.
-        -->
-        <CopyrightCurrentYear Condition=" '$(COPYRIGHT_CURRENT_YEAR)' != '' ">$(COPYRIGHT_CURRENT_YEAR)</CopyrightCurrentYear>
-        <CopyrightCurrentYear Condition=" '$(CopyrightCurrentYear)' == '' ">2026</CopyrightCurrentYear>
-        <CopyrightYearRange Condition=" '$(CopyrightStartYear)' == '$(CopyrightCurrentYear)' ">$(CopyrightStartYear)</CopyrightYearRange>
-        <CopyrightYearRange Condition=" '$(CopyrightYearRange)' == '' ">$(CopyrightStartYear)-$(CopyrightCurrentYear)</CopyrightYearRange>
-        <Copyright>Copyright © $(CopyrightYearRange) $(CopyrightOwner)</Copyright>
     </PropertyGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -439,14 +439,94 @@ dotnet test AspectCentral.DispatchProxy.Tests/AspectCentral.DispatchProxy.Tests.
 # Run a single class or method (xUnit filter syntax)
 dotnet test --filter "FullyQualifiedName~BaseAspectTests"
 
-# Pack the NuGet (matches azure-pipelines.yml)
+# Pack the NuGet (the workflow runs the equivalent of this)
 dotnet pack AspectCentral.DispatchProxy/AspectCentral.DispatchProxy.csproj --configuration Release
 ```
 
-CI (`azure-pipelines.yml`) additionally runs SonarCloud analysis, signs the `.nupkg` with
-`dotnet sign` against Azure Artifact Signing (workload-identity federation, no client secrets),
-and publishes artifacts. Local builds get a `-local` suffix; Debug CI
-builds get `-$(BUILD_BUILDNUMBER)-preview`.
+CI runs in **GitHub Actions** via a single workflow:
+[`.github/workflows/ci.yml`](./.github/workflows/ci.yml). It contains three jobs:
+
+- **`build-test`** — runs on every push to `develop`, `main`, `master`, `feature/**`,
+  `release/**`, `hotfix/**`, on PRs to `develop`/`main`/`master`, and on `v*` tags.
+  Restores, builds, tests on `net9.0` + `net10.0`, runs SonarCloud (when `vars.SONAR_PROJECT_KEY`
+  is set), and uploads a preview `*.nupkg` artifact suffixed `-ci.<run_number>`.
+- **`publish-rc`** — `needs: build-test`. Runs only on `release/**` branches. Signs the
+  package with **Azure Trusted Signing** (OIDC, no secrets) and pushes to nuget.org via
+  **NuGet Trusted Publishing** (OIDC, no API key).
+- **`publish-stable`** — `needs: build-test`. Runs only on `v*` tags. Same sign/push as
+  RC plus a GitHub Release. Verifies the tag matches `<VersionPrefix>` and that the tagged
+  commit is reachable from `master`.
+
+Both publish jobs gate on `build-test` succeeding first — there is no way to ship an
+untested package. See **Release Process** below.
+
+---
+
+## Release Process
+
+This repository follows **GitFlow with separate RC and stable channels**, both driven by
+the single workflow [`.github/workflows/ci.yml`](./.github/workflows/ci.yml). The git ref
+decides which publish job runs (after `build-test` passes).
+
+### Channels
+
+| Trigger | Job | Version produced | Example |
+|---|---|---|---|
+| Push to `release/X.Y.Z` branch | `publish-rc` | `<VersionPrefix>-rc.<run_number>` | `2.0.0-rc.42` |
+| Push tag `vX.Y.Z` | `publish-stable` | `<VersionPrefix>` | `2.0.0` |
+
+`<VersionPrefix>` is the value in
+[`AspectCentral.DispatchProxy.csproj`](./AspectCentral.DispatchProxy/AspectCentral.DispatchProxy.csproj)
+(currently `2.0.0`). The two channels share that single source of truth — bumping it bumps both.
+
+### End-to-end flow for a new release
+
+1. Cut the release branch from `develop`:
+   ```bash
+   git checkout develop && git pull
+   git checkout -b release/2.0.0
+   git push -u origin release/2.0.0
+   ```
+   → `publish-rc` ships `2.0.0-rc.1` to nuget.org.
+2. Land bug fixes on `release/2.0.0` (PR or direct push). Each push ships
+   `2.0.0-rc.2`, `-rc.3`, … so consumers can validate against real RCs.
+3. Bump `<VersionPrefix>` in the `.csproj` only when the **next** release should change
+   (e.g. you decide to ship `2.0.1` instead of `2.0.0`). Patch/minor RCs of the same target
+   stay on the same prefix.
+4. When the RC is accepted:
+   - PR `release/2.0.0` → `master`. Merge.
+   - Tag the merge commit on `master`:
+     ```bash
+     git checkout master && git pull
+     git tag v2.0.0 && git push origin v2.0.0
+     ```
+     → `publish-stable` ships `2.0.0` to nuget.org and creates a GitHub Release.
+   - Back-merge `release/2.0.0` → `develop` so any release-only fixes flow back.
+
+### Safety checks on `publish-stable`
+
+- **Tag must match `<VersionPrefix>`.** `v2.0.0` against a csproj of `<VersionPrefix>2.0.1</VersionPrefix>`
+  fails before signing.
+- **Tag commit must be reachable from `master`.** Tagging a feature branch fails the workflow.
+
+### What never publishes
+
+- Pushes to `develop`, `feature/**`, `hotfix/**`, or PRs — these only run `ci.yml`.
+- Pushes to `release/**` whose CI fails — `publish-rc` runs in the same workflow as build/test
+  and stops on the first failed step.
+
+### Required GitHub configuration
+
+The `release` GitHub Environment must exist on the repo (it scopes the OIDC subject claim,
+satisfies the nuget.org Trusted Publishing policy, and gates secret access). Configuration is
+shared at the **org level**:
+
+- **Org secrets:** `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `NUGET_USER`
+- **Org variables:** `TRUSTED_SIGNING_ENDPOINT`, `TRUSTED_SIGNING_ACCOUNT`, `TRUSTED_SIGNING_PROFILE`
+  (and optionally `SONAR_PROJECT_KEY`)
+
+The Entra app registration backing `AZURE_CLIENT_ID` needs a federated credential whose
+subject is `repo:jamesconsultingllc/AspectCentral.DispatchProxy:environment:release`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -522,8 +522,9 @@ satisfies the nuget.org Trusted Publishing policy, and gates secret access). Con
 shared at the **org level**:
 
 - **Org secrets:** `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `NUGET_USER`
+  (and optionally `SONAR_TOKEN` when SonarCloud analysis is enabled)
 - **Org variables:** `TRUSTED_SIGNING_ENDPOINT`, `TRUSTED_SIGNING_ACCOUNT`, `TRUSTED_SIGNING_PROFILE`
-  (and optionally `SONAR_PROJECT_KEY`)
+  (and optionally `SONAR_PROJECT_KEY` and `SONAR_ORG` when SonarCloud analysis is enabled)
 
 The Entra app registration backing `AZURE_CLIENT_ID` needs a federated credential whose
 subject is `repo:jamesconsultingllc/AspectCentral.DispatchProxy:environment:release`.


### PR DESCRIPTION
Pin azure/login, NuGet/login, and softprops/action-gh-release to commit SHAs in the publish jobs.

Mirrors the same fix shipped to JC Core (jamesconsultingllc/james-consulting-core#26 commit `112a580`) — same 5 SonarCloud hotspots will appear here once Sonar runs against this repo, and pinning ahead of time avoids re-opening hardened workflows mid-release.

| action | tag | pinned SHA |
|---|---|---|
| `azure/login` | v2.3.0 | `a457da9ea143d694b1b9c7c869ebb04ebe844ef5` |
| `NuGet/login` | v1.2.0 | `8d196754b4036150537f80ac539e15c2f1028841` |
| `softprops/action-gh-release` | v2 (latest in v2 line) | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` |

`actions/*` (checkout, setup-dotnet, setup-java, upload-artifact) intentionally left on `@v4` — Sonar does not flag GitHub-owned org actions.

Also quotes `$SOLUTION` / `$PACKAGE_PROJECT` in the Linux bash `run:` steps to address the actionlint SC2086 warnings (the PowerShell branches use `$env:SOLUTION` which is unaffected).

---

## Additional fix: `BaseAspect<T>` synchronous exception unwrapping

Commit `b4ce806` adds `BindingFlags.DoNotWrapExceptions` to all six `MethodInfo.Invoke` sites in `BaseAspect<T>` (lines ~276, 335, 455, 461, 497, 517).

**Bug**: synchronous target-method exceptions were caught and recorded to OTel telemetry as `System.Reflection.TargetInvocationException` (with a reflection-plumbing stack trace) instead of the originating exception type, and rethrown to consumers as `TargetInvocationException`, breaking caller `try/catch` blocks targeting specific exception types.

**Fix**: pass `BindingFlags.DoNotWrapExceptions` so the runtime propagates the original exception. Available on netstandard2.1+ / net5+, which covers every TFM this library targets. Async paths were already correct (`Task.Exception` auto-unwraps).

**Tests**: existing `CoverageTests.BaseAspect_PropagatesSyncExceptionAndRecordsErrorTelemetry` was asserting the buggy `TargetInvocationException` rethrow as if correct — updated to assert on the unwrapped `InvalidOperationException`. 88/88 tests pass on net9.0 and net10.0.

**SemVer**: lands in the unreleased 2.0.0 window (only `2.0.0-rc.9` and `-rc.10` published). Will be called out in the 2.0.0 release notes.


---

## Build/pack metadata: `Directory.Build.props`

Replaced the prior bespoke `CopyrightStartYear` / `CurrentYear` / `YearRange` / `COPYRIGHT_CURRENT_YEAR` env-var machinery (~30 lines) with a simpler MSBuild conditional pattern (~7 lines) that:

- Sets `_CopyrightStartYear=2019` (verified via first-commit date).
- Computes `_CopyrightCurrentYear` from `$([System.DateTime]::UtcNow.Year)` (UTC for cross-timezone build determinism).
- Collapses the year range when start == current (e.g. emits `2026` instead of `2026 - 2026`).
- Composes the final `<Copyright>` string from `$(Company)` so there is no duplicated authorship literal.

Resulting metadata string: `Copyright (c) 2019 - 2026 James Consulting LLC. All Rights Reserved.`

This pattern was rolled out consistently across all four James Consulting LLC repos (DispatchProxy, JamesConsulting core, template-library, template-server) over the same review cycle.
