### PR TITLE
refactor: address Sonar code-quality issues (S3011, S3267, S4136, S3776)

### DIFF
--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
@@ -1,0 +1,60 @@
+//  ----------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ShortCircuitAspect.cs" company="James Consulting LLC">
+//    Copyright (c) 2026 James Consulting LLC. Licensed under the MIT License.
+//  </copyright>
+//  ----------------------------------------------------------------------------------------------------------------------
+
+using AspectCentral.Abstractions;
+using AspectCentral.Abstractions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AspectCentral.DispatchProxy.Tests;
+
+/// <summary>
+/// Test aspect that short-circuits intercepted calls without supplying a generic
+/// <see cref="Task{TResult}" /> result. Used to exercise the sync short-circuit branch
+/// and the non-generic <see cref="Task" /> short-circuit branch of
+/// <c>BaseAspect&lt;T&gt;.DispatchIntercepted</c> / <c>HandleAsyncShortCircuit</c>.
+/// </summary>
+/// <typeparam name="T">The interface type being proxied.</typeparam>
+public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
+{
+    /// <summary>
+    /// When <see langword="true" />, <see cref="PreInvoke" /> sets
+    /// <see cref="AspectContext.ReturnValue" /> to <see cref="Task.CompletedTask" /> (a
+    /// non-generic <see cref="Task" />) to exercise the non-generic Task short-circuit path.
+    /// When <see langword="false" />, <see cref="PreInvoke" /> leaves ReturnValue at its default
+    /// to exercise the sync short-circuit / fallback PostInvoke path.
+    /// </summary>
+    public static bool SupplyNonGenericTask { get; set; }
+
+    /// <summary>Records that PostInvoke ran.</summary>
+    public static bool PostInvokeRan { get; set; }
+
+    /// <summary>Creates a configured short-circuit proxy.</summary>
+    public static T Create(T instance, Type type, ILoggerFactory loggerFactory,
+        IAspectConfigurationProvider provider)
+    {
+        object proxy = Create<T, ShortCircuitAspect<T>>()!;
+        var typed = (ShortCircuitAspect<T>)proxy;
+        typed.Instance = instance;
+        typed.ObjectType = type;
+        typed.AspectConfigurationProvider = provider;
+        typed.Logger = loggerFactory.CreateLogger(type.FullName!);
+        typed.FactoryType = TestAspectFactory.Type;
+        return (T)proxy;
+    }
+
+    /// <inheritdoc />
+    public override void PreInvoke(AspectContext aspectContext)
+    {
+        aspectContext.InvokeMethod = false;
+        if (SupplyNonGenericTask) aspectContext.ReturnValue = Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override void PostInvoke(AspectContext aspectContext)
+    {
+        PostInvokeRan = true;
+    }
+}

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspectTests.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspectTests.cs
@@ -1,0 +1,75 @@
+//  ----------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ShortCircuitAspectTests.cs" company="James Consulting LLC">
+//    Copyright (c) 2026 James Consulting LLC. Licensed under the MIT License.
+//  </copyright>
+//  ----------------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+using AspectCentral.Abstractions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace AspectCentral.DispatchProxy.Tests;
+
+/// <summary>
+/// Coverage tests for the short-circuit branches of
+/// <c>BaseAspect&lt;T&gt;.DispatchIntercepted</c> and
+/// <c>BaseAspect&lt;T&gt;.HandleAsyncShortCircuit</c>:
+/// (1) sync method with <c>InvokeMethod=false</c> and no Task supplied (fallback PostInvoke), and
+/// (2) async method with <c>InvokeMethod=false</c> returning a non-generic
+/// <see cref="Task" /> (Task continuation path).
+/// </summary>
+public class ShortCircuitAspectTests
+{
+    private static readonly Type ITestInterfaceType = typeof(ITestInterface);
+
+    private ITestInterface CreateProxy()
+    {
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(typeof(MyTestInterface).FullName!).Returns(new RecordingLogger());
+        var provider = Substitute.For<IAspectConfigurationProvider>();
+        provider.ShouldIntercept(Arg.Any<Type>(), Arg.Any<Type>(), Arg.Any<Type>(), Arg.Any<MethodInfo>())
+            .Returns(true);
+        var config = new AspectConfiguration(
+            new ServiceDescriptor(ITestInterfaceType, MyTestInterface.Type, ServiceLifetime.Transient));
+        config.AddEntry(TestAspectFactory.Type, methodsToIntercept: ITestInterfaceType.GetMethods());
+        provider.AddEntry(config);
+        return ShortCircuitAspect<ITestInterface>.Create(new MyTestInterface(), typeof(MyTestInterface),
+            loggerFactory, provider);
+    }
+
+    /// <summary>
+    /// Sync method, InvokeMethod=false, no Task supplied — exercises the fallback
+    /// <c>PostInvoke(aspectContext)</c> branch in <c>DispatchIntercepted</c>.
+    /// </summary>
+    [Fact]
+    public void SyncShortCircuit_RunsPostInvoke()
+    {
+        ShortCircuitAspect<ITestInterface>.SupplyNonGenericTask = false;
+        ShortCircuitAspect<ITestInterface>.PostInvokeRan = false;
+
+        var proxy = CreateProxy();
+        proxy.Test(1, "x", new MyUnitTestClass(1, "x"));
+
+        Assert.True(ShortCircuitAspect<ITestInterface>.PostInvokeRan);
+    }
+
+    /// <summary>
+    /// Async method returning <see cref="Task" /> (non-generic), InvokeMethod=false,
+    /// non-generic Task supplied — exercises the <c>ContinueWith</c> branch of
+    /// <c>HandleAsyncShortCircuit</c>.
+    /// </summary>
+    [Fact]
+    public async Task NonGenericTaskShortCircuit_RunsPostInvoke()
+    {
+        ShortCircuitAspect<ITestInterface>.SupplyNonGenericTask = true;
+        ShortCircuitAspect<ITestInterface>.PostInvokeRan = false;
+
+        var proxy = CreateProxy();
+        await proxy.TestAsync(1, "x", new MyUnitTestClass(1, "x"));
+
+        Assert.True(ShortCircuitAspect<ITestInterface>.PostInvokeRan);
+    }
+}

--- a/AspectCentral.DispatchProxy/BaseAspect.cs
+++ b/AspectCentral.DispatchProxy/BaseAspect.cs
@@ -249,60 +249,7 @@ public abstract class BaseAspect<T> : System.Reflection.DispatchProxy where T : 
 
         try
         {
-            if (ShouldIntercept(aspectContext))
-            {
-                PreInvoke(aspectContext);
-
-                if (aspectContext.InvokeMethod)
-                {
-                    AspectLogs.InvokingWithInterception(Logger, aspectContext.InvocationString ?? "Unknown");
-                    Invoke(aspectContext);
-                    // For async methods, PostInvoke is wired into the task continuation by
-                    // ProcessAction / CallProcessFunction (via BaseAspectAsyncProcessor). For sync
-                    // methods, PostInvoke must be invoked here.
-                    if (!isAsync) PostInvoke(aspectContext);
-                }
-                else if (isAsync && aspectContext.ReturnValue is Task shortCircuitTask)
-                {
-                    // Async short-circuit: the aspect supplied a Task return value without invoking
-                    // the target. Wire PostInvoke through the same async machinery as the normal
-                    // intercepted path so PostInvoke observes the unwrapped TResult (not the
-                    // Task<TResult> wrapper) and so cleanup reliably runs in the task's continuation.
-                    var taskType = shortCircuitTask.GetType();
-                    if (taskType.IsGenericType && taskType.GetGenericTypeDefinition() == typeof(Task<>))
-                    {
-                        var resultType = taskType.GetGenericArguments()[0];
-                        var mi = BaseAspectAsyncProcessor.ProcessFunctionMethodInfo.MakeGenericMethod(resultType);
-                        aspectContext.ReturnValue = mi.Invoke(
-                            null,
-                            BindingFlags.DoNotWrapExceptions,
-                            binder: null,
-                            parameters: [shortCircuitTask, aspectContext, (Action<AspectContext>)PostInvoke],
-                            culture: null);
-                    }
-                    else
-                    {
-                        // Non-generic Task — no result to unwrap; just attach PostInvoke.
-                        var ctx = aspectContext;
-                        shortCircuitTask.ContinueWith(
-                            _ => PostInvoke(ctx),
-                            CancellationToken.None,
-                            TaskContinuationOptions.ExecuteSynchronously,
-                            TaskScheduler.Default);
-                    }
-                }
-                else
-                {
-                    // Sync short-circuit, or async short-circuit with no Task supplied. Run PostInvoke
-                    // immediately so aspects can reliably perform cleanup.
-                    PostInvoke(aspectContext);
-                }
-            }
-            else
-            {
-                AspectLogs.InvokingWithoutInterception(Logger, aspectContext.InvocationString ?? "Unknown");
-                InvokeWithoutInterception(aspectContext);
-            }
+            DispatchInvocation(aspectContext, isAsync);
 
             if (isAsync && aspectContext.ReturnValue is Task taskResult)
             {
@@ -323,6 +270,88 @@ public abstract class BaseAspect<T> : System.Reflection.DispatchProxy where T : 
             CompleteError(activity, sw, ex);
             throw;
         }
+    }
+
+    /// <summary>
+    /// Routes the invocation to either the intercepted or pass-through path based on
+    /// <see cref="ShouldIntercept" />. Extracted from <see cref="Invoke(System.Reflection.MethodInfo, object[])" />
+    /// to keep its cognitive complexity below the Sonar S3776 threshold.
+    /// </summary>
+    private void DispatchInvocation(AspectContext aspectContext, bool isAsync)
+    {
+        if (ShouldIntercept(aspectContext))
+        {
+            DispatchIntercepted(aspectContext, isAsync);
+        }
+        else
+        {
+            AspectLogs.InvokingWithoutInterception(Logger, aspectContext.InvocationString ?? "Unknown");
+            InvokeWithoutInterception(aspectContext);
+        }
+    }
+
+    /// <summary>
+    /// Runs the aspect's <see cref="PreInvoke" />, dispatches to the target (or honors a
+    /// short-circuit), and wires <see cref="PostInvoke" /> appropriately for sync vs async paths.
+    /// </summary>
+    private void DispatchIntercepted(AspectContext aspectContext, bool isAsync)
+    {
+        PreInvoke(aspectContext);
+
+        if (aspectContext.InvokeMethod)
+        {
+            AspectLogs.InvokingWithInterception(Logger, aspectContext.InvocationString ?? "Unknown");
+            Invoke(aspectContext);
+            // For async methods, PostInvoke is wired into the task continuation by
+            // ProcessAction / CallProcessFunction (via BaseAspectAsyncProcessor). For sync
+            // methods, PostInvoke must be invoked here.
+            if (!isAsync) PostInvoke(aspectContext);
+            return;
+        }
+
+        if (isAsync && aspectContext.ReturnValue is Task shortCircuitTask)
+        {
+            // Async short-circuit: the aspect supplied a Task return value without invoking
+            // the target. Wire PostInvoke through the same async machinery as the normal
+            // intercepted path so PostInvoke observes the unwrapped TResult (not the
+            // Task<TResult> wrapper) and so cleanup reliably runs in the task's continuation.
+            HandleAsyncShortCircuit(aspectContext, shortCircuitTask);
+            return;
+        }
+
+        // Sync short-circuit, or async short-circuit with no Task supplied. Run PostInvoke
+        // immediately so aspects can reliably perform cleanup.
+        PostInvoke(aspectContext);
+    }
+
+    /// <summary>
+    /// Handles an async short-circuit: routes <see cref="Task{TResult}" /> results through the
+    /// generic async processor so <see cref="PostInvoke" /> observes the unwrapped result, and
+    /// attaches a continuation for non-generic <see cref="Task" /> results.
+    /// </summary>
+    private void HandleAsyncShortCircuit(AspectContext aspectContext, Task shortCircuitTask)
+    {
+        var taskType = shortCircuitTask.GetType();
+        if (taskType.IsGenericType && taskType.GetGenericTypeDefinition() == typeof(Task<>))
+        {
+            var resultType = taskType.GetGenericArguments()[0];
+            var mi = BaseAspectAsyncProcessor.ProcessFunctionMethodInfo.MakeGenericMethod(resultType);
+            aspectContext.ReturnValue = mi.Invoke(
+                null,
+                BindingFlags.DoNotWrapExceptions,
+                binder: null,
+                parameters: [shortCircuitTask, aspectContext, (Action<AspectContext>)PostInvoke],
+                culture: null);
+            return;
+        }
+
+        // Non-generic Task — no result to unwrap; just attach PostInvoke.
+        var ctx = aspectContext;
+        shortCircuitTask.ContinueWith(
+            _ => PostInvoke(ctx),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     /// <summary>

--- a/AspectCentral.DispatchProxy/DispatchProxyAspectRegistrationBuilder.cs
+++ b/AspectCentral.DispatchProxy/DispatchProxyAspectRegistrationBuilder.cs
@@ -20,6 +20,13 @@ public class DispatchProxyAspectRegistrationBuilder(
     /// Cached <see cref="MethodInfo" /> for the private generic factory method used to build
     /// proxy instances after aspects have been registered fluently.
     /// </summary>
+    /// <remarks>
+    /// <c>BindingFlags.NonPublic</c> is intentional: <c>CreateFactory&lt;TService&gt;</c> is a private
+    /// generic invoked by <see cref="InvokeCreateFactory" /> after closing it over the runtime
+    /// <c>TService</c>. It is not API.
+    /// </remarks>
+    [SuppressMessage("Major Code Smell", "S3011:Reflection should not be used to increase accessibility of classes, methods, or fields",
+        Justification = "Intentional: CreateFactory<TService> is a private generic factory closed over runtime TService in InvokeCreateFactory; it is not API.")]
     private static readonly MethodInfo CreateFactoryMethodInfo =
         typeof(DispatchProxyAspectRegistrationBuilder).GetMethod(nameof(CreateFactory),
             BindingFlags.Static | BindingFlags.NonPublic)!;
@@ -74,10 +81,9 @@ public class DispatchProxyAspectRegistrationBuilder(
                 ? (TService)f.GetRequiredService(aspectConfiguration.ServiceDescriptor.ImplementationType)
                 : instance!;
 
-        foreach (var aspect in aspectConfiguration.GetAspects())
+        foreach (var aspectType in aspectConfiguration.GetAspects().Select(a => a.AspectType))
         {
             var temp = factory;
-            var aspectType = aspect.AspectType;
             factory = f =>
             {
                 var interceptorFactory = (IAspectFactory)f.GetRequiredService(aspectType);

--- a/AspectCentral.DispatchProxy/ServiceCollectionExtensions.cs
+++ b/AspectCentral.DispatchProxy/ServiceCollectionExtensions.cs
@@ -28,6 +28,14 @@ public static class ServiceCollectionExtensions
     /// Cached <see cref="MethodInfo" /> for the private generic <c>CreateFactory&lt;TService&gt;</c>
     /// used to construct the aspect chain at service-resolution time.
     /// </summary>
+    /// <remarks>
+    /// <c>BindingFlags.NonPublic</c> is intentional: <c>CreateFactory&lt;TService&gt;</c> is a private
+    /// static generic invoked by <see cref="InvokeCreateFactory" /> after closing it over the
+    /// runtime <c>TService</c>. Exposing it publicly would not be safe — it's a DI factory
+    /// callback, not an API.
+    /// </remarks>
+    [SuppressMessage("Major Code Smell", "S3011:Reflection should not be used to increase accessibility of classes, methods, or fields",
+        Justification = "Intentional: CreateFactory<TService> is a private generic factory closed over runtime TService in InvokeCreateFactory; it is not API.")]
     private static readonly MethodInfo CreateFactoryMethodInfo =
         typeof(ServiceCollectionExtensions).GetMethod(nameof(CreateFactory),
             BindingFlags.Static | BindingFlags.NonPublic)!;
@@ -278,10 +286,9 @@ public static class ServiceCollectionExtensions
         Func<IServiceProvider, TService> factory = f =>
             (TService)f.GetRequiredService(aspectConfiguration.ServiceDescriptor.ImplementationType!);
 
-        foreach (var aspect in aspectConfiguration.GetAspects())
+        foreach (var aspectType in aspectConfiguration.GetAspects().Select(a => a.AspectType))
         {
             var temp = factory;
-            var aspectType = aspect.AspectType;
             factory = f =>
             {
                 var interceptorFactory = (IAspectFactory)f.GetRequiredService(aspectType);
@@ -325,6 +332,38 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Scans the supplied assemblies for concrete <see cref="IAspectFactory" /> implementations and
+    /// registers each as a singleton (idempotent via <c>TryAddSingleton</c>). Assemblies that fail
+    /// <see cref="System.Reflection.Assembly.GetTypes" /> with a <see cref="ReflectionTypeLoadException" />
+    /// contribute whatever non-null types the runtime managed to load.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    private static IServiceCollection RegisterAspectFactories(this IServiceCollection serviceCollection,
+        Assembly[] assembliesToScan)
+    {
+        var types = assembliesToScan
+            .SelectMany(assembly =>
+            {
+                try
+                {
+                    return assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException ex)
+                {
+                    return ex.Types.Where(t => t != null)!;
+                }
+            })
+            .Where(type => type != null && !type.IsAbstract && !type.IsInterface &&
+                           Constants.IAspectFactoryType.IsAssignableFrom(type))
+            .Select(type => type!);
+
+        foreach (var type in types)
+            serviceCollection.TryAddSingleton(type);
+
+        return serviceCollection;
+    }
+
+    /// <summary>
     /// Returns the already-registered singleton <see cref="IAspectConfigurationProvider" />
     /// instance from <paramref name="serviceCollection" /> if one exists, otherwise registers a
     /// new <see cref="InMemoryAspectConfigurationProvider" /> as a singleton instance and returns
@@ -360,37 +399,5 @@ public static class ServiceCollectionExtensions
         var provider = new InMemoryAspectConfigurationProvider();
         serviceCollection.AddSingleton<IAspectConfigurationProvider>(provider);
         return provider;
-    }
-
-    /// <summary>
-    /// Scans the supplied assemblies for concrete <see cref="IAspectFactory" /> implementations and
-    /// registers each as a singleton (idempotent via <c>TryAddSingleton</c>). Assemblies that fail
-    /// <see cref="System.Reflection.Assembly.GetTypes" /> with a <see cref="ReflectionTypeLoadException" />
-    /// contribute whatever non-null types the runtime managed to load.
-    /// </summary>
-    [ExcludeFromCodeCoverage]
-    private static IServiceCollection RegisterAspectFactories(this IServiceCollection serviceCollection,
-        Assembly[] assembliesToScan)
-    {
-        var types = assembliesToScan
-            .SelectMany(assembly =>
-            {
-                try
-                {
-                    return assembly.GetTypes();
-                }
-                catch (ReflectionTypeLoadException ex)
-                {
-                    return ex.Types.Where(t => t != null)!;
-                }
-            })
-            .Where(type => type != null && !type.IsAbstract && !type.IsInterface &&
-                           Constants.IAspectFactoryType.IsAssignableFrom(type));
-
-        foreach (var type in types)
-            if (type != null)
-                serviceCollection.TryAddSingleton(type);
-
-        return serviceCollection;
     }
 }


### PR DESCRIPTION
Addresses the seven Sonar code-quality findings surfaced on the **Build, Test, Analyze** job during PR #7's checks. Pure refactor — no behavior change. All 88 tests pass on net9.0 and net10.0.

## Issues fixed

| File | Line | Rule | Fix |
|---|---|---|---|
| ServiceCollectionExtensions.cs | 33 | **S3011** — accessibility bypass | `[SuppressMessage]` + justification — `CreateFactory<TService>` is a private generic factory closed over runtime `TService` by `InvokeCreateFactory`; exposing it publicly would not be safe. |
| ServiceCollectionExtensions.cs | 281 | **S3267** — foreach → Select | `foreach (var aspect in ...) { var aspectType = aspect.AspectType; }` → `foreach (var aspectType in ....Select(a => a.AspectType))`. |
| ServiceCollectionExtensions.cs | 322 | **S4136** — overload adjacency | Moved `GetOrAddInMemoryProvider` below both `RegisterAspectFactories` overloads so the overloads sit adjacent. |
| ServiceCollectionExtensions.cs | 390 | **S3267** —
| DispatchProxyAspectRegistrationBuilder.cs | 25 | **S3011** — accessibility bypass | Same suppression + justification as above. |
| DispatchProxyAspectRegistrationBuilder.cs | 77 | **S3267** — foreach → Select | Same Select cleanup as the ServiceCollectionExtensions counterpart. |
| BaseAspect.cs | 226 | **S3776** — cognitive complexity 20 > 15 | Split `Invoke` into four focused methods: top-level `Invoke` (activity setup + telemetry dispatch + async detach), `DispatchInvocation` (intercept vs pass-through), `DispatchIntercepted` (PreInvoke + InvokeMethod branching + sync PostInvoke), and `HandleAsyncShortCircuit` (Task<T> via `BaseAspectAsyncProcessor` vs non-generic Task via continuation). |

## Verification
- `dotnet build` — 0 warnings, 0 errors on netstandard2.1, net9.0, net10.0
- `dotnet test` — 88 passed × 2 TFMs

## Out of scope
Stable v2.0.0 ship is still gated on AspectCentral.Abstractions 2.0.0 stable being on nuget.org.