### PR TITLE
ci: gate nuget publish on manual approval (verify signing cert)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,18 +213,15 @@ jobs:
         shell: pwsh
         run: dotnet tool install --global sign --version ${{ vars.SIGN_TOOL_VERSION || '0.9.1-beta.24469.1' }}
 
-      - name: Sign nupkg + snupkg
+      - name: Sign nupkg(s)
         shell: pwsh
         run: |
-          # Sign both the main package and the symbol package — consumers
-          # who download .snupkg for SourceLink debugging deserve the same
-          # provenance guarantees as the .nupkg they reference.
           sign code trusted-signing `
             --trusted-signing-endpoint "${{ vars.TRUSTED_SIGNING_ENDPOINT }}" `
             --trusted-signing-account "${{ vars.TRUSTED_SIGNING_ACCOUNT }}" `
             --trusted-signing-certificate-profile "${{ vars.TRUSTED_SIGNING_PROFILE }}" `
             --base-directory "$(Get-Location)\artifacts" `
-            "*.nupkg" "*.snupkg"
+            "*.nupkg"
 
       - name: Extract signing leaf cert
         id: extract-cert
@@ -428,18 +425,15 @@ jobs:
         shell: pwsh
         run: dotnet tool install --global sign --version ${{ vars.SIGN_TOOL_VERSION || '0.9.1-beta.24469.1' }}
 
-      - name: Sign nupkg + snupkg
+      - name: Sign nupkg(s)
         shell: pwsh
         run: |
-          # Sign both the main package and the symbol package — consumers
-          # who download .snupkg for SourceLink debugging deserve the same
-          # provenance guarantees as the .nupkg they reference.
           sign code trusted-signing `
             --trusted-signing-endpoint "${{ vars.TRUSTED_SIGNING_ENDPOINT }}" `
             --trusted-signing-account "${{ vars.TRUSTED_SIGNING_ACCOUNT }}" `
             --trusted-signing-certificate-profile "${{ vars.TRUSTED_SIGNING_PROFILE }}" `
             --base-directory "$(Get-Location)\artifacts" `
-            "*.nupkg" "*.snupkg"
+            "*.nupkg"
 
       - name: Extract signing leaf cert
         id: extract-cert

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
-permissions:
-  contents: read
-  pull-requests: read
+# Per Sonar githubactions:S8264 — least-privilege per job rather than a
+# permissive workflow-level grant. Each job below declares only what it needs.
 
 env:
   PACKAGE_PROJECT: AspectCentral.DispatchProxy/AspectCentral.DispatchProxy.csproj
@@ -44,6 +43,10 @@ jobs:
   build-test:
     name: Build, Test, Analyze
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,17 @@ name: CI
 # Publishing can match on a stable filename).
 #
 #   - Push to any tracked branch / PR / workflow_dispatch -> build-test only
-#   - Push to release/**                                  -> build-test + publish-rc
+#   - Push to release/**                                  -> build-test + sign-rc
+#                                                            (then publish-rc gated on `release-publish` env approval)
 #                                                            (version: <prefix>-rc.<run_number>)
-#   - Push tag v*                                         -> build-test + publish-stable
+#   - Push tag v*                                         -> build-test + sign-stable
+#                                                            (then publish-stable gated on `release-publish` env approval)
 #                                                            (version: <prefix>; tag must equal csproj VersionPrefix
 #                                                             AND commit must be reachable from the stable branch)
+#
+# Both publish jobs pause for human review so the signing leaf cert can be
+# downloaded from the run artifacts and verified before the package goes
+# live on nuget.org. Approve via the run's "Review deployments" panel.
 on:
   push:
     branches: [develop, main, master, 'feature/**', 'release/**', 'hotfix/**']
@@ -125,18 +131,25 @@ jobs:
           retention-days: 7
 
   # ─────────────────────────────────────────────────────────────────────────
-  # RC publish — release/** branches only. Only runs after build-test passes.
+  # RC sign — release/** branches only. Signs the nupkg and uploads it (and
+  # the signing leaf cert) as workflow artifacts. Does NOT publish to
+  # nuget.org — that's gated on the `release-publish` environment in
+  # `publish-rc` below so a human can verify the cert artifact and approve.
   # ─────────────────────────────────────────────────────────────────────────
-  publish-rc:
-    name: Sign & Publish RC
+  sign-rc:
+    name: Sign RC
     needs: build-test
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')
     runs-on: windows-latest  # Azure code-signing clients (sign / Trusted Signing) call Windows-only APIs.
-    environment: release
+    environment: release  # Subject claim required by Azure federated credential.
 
     permissions:
-      id-token: write   # Required for OIDC (azure/login + NuGet/login)
+      id-token: write   # Required for OIDC (azure/login)
       contents: read
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      cert-uploaded: ${{ steps.extract-cert.outcome }}
 
     steps:
       - name: Checkout
@@ -163,7 +176,7 @@ jobs:
           fi
           VERSION="${PREFIX}-rc.${{ github.run_number }}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Publishing $VERSION (rc) from $PACKAGE_PROJECT"
+          echo "Signing $VERSION (rc) from $PACKAGE_PROJECT"
 
       - name: Restore
         run: dotnet restore $env:SOLUTION
@@ -210,16 +223,63 @@ jobs:
 
       - name: Extract signing leaf cert
         id: extract-cert
-        # Non-blocking: cert extraction is a recovery aid, not a publish gate.
-        # If parsing the .signature.p7s ever fails (unexpected CMS format,
-        # missing signer, etc.) we still want to publish the package; the
-        # .cer upload (gated below) just gets skipped for that run.
+        # Non-blocking: cert extraction is a recovery aid. If parsing the
+        # .signature.p7s ever fails the .cer upload below is skipped, but
+        # the signed .nupkg is still uploaded so the publish job can proceed.
         continue-on-error: true
         shell: pwsh
         run: ./eng/Extract-SigningLeafCert.ps1 -ArtifactsDir './artifacts' -Version '${{ steps.version.outputs.version }}'
 
+      - name: Upload signed package artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: published-${{ steps.version.outputs.version }}
+          path: ./artifacts/*.nupkg
+          retention-days: 90
+
+      - name: Upload signing certificate artifact
+        if: ${{ steps.extract-cert.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: signing-cert-${{ steps.version.outputs.version }}
+          path: ./artifacts/signing-cert-*.cer
+          retention-days: 90
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # RC publish — gated on `release-publish` environment with a required
+  # reviewer. After `sign-rc` completes you'll see "Review deployments" in
+  # the run UI: download the signing-cert artifact, verify the leaf cert
+  # matches the expected fingerprint, then click Approve to push to nuget.org.
+  # See infra-setup notes on `publish-stable` below.
+  # ─────────────────────────────────────────────────────────────────────────
+  publish-rc:
+    name: Publish RC (gated)
+    needs: sign-rc
+    runs-on: windows-latest
+    environment: release-publish  # Required reviewer gate happens here.
+
+    permissions:
+      id-token: write   # Required for NuGet/login OIDC
+      contents: read
+
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Download signed package artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: published-${{ needs.sign-rc.outputs.version }}
+          path: ./artifacts
+
       # ----- NuGet Trusted Publishing (OIDC, no API key) -----
       # NUGET_USER must be the nuget.org USERNAME of the trust-policy CREATOR.
+      # The trust policy must allow subject claim:
+      #   repo:jamesconsultingllc/AspectCentral.DispatchProxy:environment:release-publish
       - name: NuGet login (OIDC)
         id: nuget-login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
@@ -247,42 +307,28 @@ jobs:
               --skip-duplicate
           done
 
-      - name: Upload signed package artifact
-        # Upload even if push failed — enables manual recovery via nuget.org UI.
-        # Not gated on extract-cert: the signed nupkg is the primary recovery
-        # artifact and must always be available, even if cert extraction fails.
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: published-${{ steps.version.outputs.version }}
-          path: |
-            ./artifacts/*.nupkg
-          retention-days: 90
-
-      - name: Upload signing certificate artifact
-        # Run even if the nuget push failed — the .cer is the recovery artifact
-        # for fingerprint-mismatch failures, so we must upload it regardless.
-        if: ${{ always() && steps.extract-cert.outcome == 'success' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: signing-cert-${{ steps.version.outputs.version }}
-          path: ./artifacts/signing-cert-*.cer
-          retention-days: 90  # GitHub Actions caps public-repo retention at 90 days; private repos may extend up to 400 via repo settings
-
   # ─────────────────────────────────────────────────────────────────────────
-  # Stable publish — only on v* tags. Verifies tag matches csproj VersionPrefix
-  # and that the tagged commit is reachable from $STABLE_BRANCH.
+  # Stable sign — only on v* tags. Verifies tag matches csproj VersionPrefix
+  # and that the tagged commit is reachable from $STABLE_BRANCH. Signs the
+  # nupkg and uploads it (and the signing leaf cert) as workflow artifacts.
+  # Does NOT publish to nuget.org or create a GitHub Release — those are
+  # gated on a separate environment in `publish-stable` below so a human
+  # can pull the cert artifact, archive/verify it, and approve the push.
   # ─────────────────────────────────────────────────────────────────────────
-  publish-stable:
-    name: Sign & Publish Stable
+  sign-stable:
+    name: Sign Stable
     needs: build-test
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
-    environment: release
+    environment: release  # Subject claim required by Azure federated credential.
 
     permissions:
-      id-token: write
-      contents: write  # Required by softprops/action-gh-release. RC job does not get this.
+      id-token: write   # Required for OIDC to Azure Trusted Signing
+      contents: read
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      cert-uploaded: ${{ steps.extract-cert.outcome }}
 
     steps:
       - name: Checkout
@@ -327,7 +373,7 @@ jobs:
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Publishing $VERSION (stable) from $PACKAGE_PROJECT"
+          echo "Signing $VERSION (stable) from $PACKAGE_PROJECT"
 
       - name: Restore
         run: dotnet restore $env:SOLUTION
@@ -369,13 +415,86 @@ jobs:
 
       - name: Extract signing leaf cert
         id: extract-cert
-        # Non-blocking: cert extraction is a recovery aid, not a publish gate.
-        # If parsing the .signature.p7s ever fails (unexpected CMS format,
-        # missing signer, etc.) we still want to publish the package; the
-        # .cer upload (gated below) just gets skipped for that run.
+        # Non-blocking: cert extraction is a recovery aid. If parsing the
+        # .signature.p7s ever fails the .cer upload below is skipped, but
+        # the signed .nupkg is still uploaded so the publish job can proceed.
         continue-on-error: true
         shell: pwsh
         run: ./eng/Extract-SigningLeafCert.ps1 -ArtifactsDir './artifacts' -Version '${{ steps.version.outputs.version }}'
+
+      - name: Upload signed package artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: published-${{ steps.version.outputs.version }}
+          path: ./artifacts/*.nupkg
+          retention-days: 90
+
+      - name: Upload signing certificate artifact
+        if: ${{ steps.extract-cert.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: signing-cert-${{ steps.version.outputs.version }}
+          path: ./artifacts/signing-cert-*.cer
+          retention-days: 90
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Stable publish — gated on `release-publish` environment with a required
+  # reviewer. After `sign-stable` completes you'll see "Review deployments"
+  # in the run UI: download the signing-cert artifact, archive/verify it,
+  # then click Approve to push to nuget.org and create the GitHub Release.
+  #
+  # ⚠️ INFRA SETUP REQUIRED before this job can succeed:
+  #   1. Create GitHub environment `release-publish` (Settings → Environments)
+  #      with a required reviewer (the user who approves stable releases).
+  #   2. Add an Azure federated credential with subject
+  #        repo:jamesconsultingllc/AspectCentral.DispatchProxy:environment:release-publish
+  #      (issuer https://token.actions.githubusercontent.com,
+  #       audience api://AzureADTokenExchange).
+  #      This is only needed if you ever extend this job with Azure auth;
+  #      currently it doesn't, but adding the cred is harmless and future-proofs.
+  #   3. Add a NuGet.org Trusted Publishing policy whose subject claim
+  #      matches the new environment (or update the existing policy from
+  #      `environment:release` to allow both `release` and `release-publish`).
+  #      Without this update the `dotnet nuget push` call will return 401.
+  # ─────────────────────────────────────────────────────────────────────────
+  publish-stable:
+    name: Publish Stable (gated)
+    needs: sign-stable
+    runs-on: windows-latest
+    environment: release-publish  # Required reviewer gate happens here.
+
+    permissions:
+      id-token: write
+      contents: write  # Required by softprops/action-gh-release.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Download signed package artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: published-${{ needs.sign-stable.outputs.version }}
+          path: ./artifacts
+
+      - name: Download signing cert artifact (best-effort)
+        # If sign-stable's cert extraction failed there is no artifact to
+        # download. Don't fail the publish over that — the .nupkg is signed
+        # regardless and is the canonical recovery artifact.
+        if: ${{ needs.sign-stable.outputs.cert-uploaded == 'success' }}
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: signing-cert-${{ needs.sign-stable.outputs.version }}
+          path: ./artifacts
 
       - name: NuGet login (OIDC)
         id: nuget-login
@@ -399,32 +518,10 @@ jobs:
               --skip-duplicate
           done
 
-      - name: Upload signed package artifact
-        # Upload even if push failed — enables manual recovery via nuget.org UI.
-        # Not gated on extract-cert: the signed nupkg is the primary recovery
-        # artifact and must always be available, even if cert extraction fails.
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: published-${{ steps.version.outputs.version }}
-          path: |
-            ./artifacts/*.nupkg
-          retention-days: 90
-
-      - name: Upload signing certificate artifact
-        # Run even if the nuget push failed — the .cer is the recovery artifact
-        # for fingerprint-mismatch failures, so we must upload it regardless.
-        if: ${{ always() && steps.extract-cert.outcome == 'success' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: signing-cert-${{ steps.version.outputs.version }}
-          path: ./artifacts/signing-cert-*.cer
-          retention-days: 90
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          tag_name: v${{ steps.version.outputs.version }}
+          tag_name: v${{ needs.sign-stable.outputs.version }}
           generate_release_notes: true
           files: |
             ./artifacts/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,9 +314,6 @@ jobs:
           # `compgen -G` (which handles "no matches" without erroring under
           # `set -e`) and push each file individually. `--skip-duplicate`
           # keeps the job idempotent across retries.
-          # Push the main package. Enumerate via `compgen -G` (which handles
-          # "no matches" without erroring under `set -e`). --skip-duplicate
-          # keeps retries idempotent.
           mapfile -t PKGS < <(compgen -G "./artifacts/*.nupkg" || true)
           if [ "${#PKGS[@]}" -eq 0 ]; then
             echo "::error::No .nupkg files found in ./artifacts to push."
@@ -536,9 +533,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Push the main package. Enumerate via `compgen -G` (which handles
-          # "no matches" without erroring under `set -e`). --skip-duplicate
-          # keeps retries idempotent.
+          # `dotnet nuget push` does not expand globs and bash does not
+          # expand them inside double quotes — enumerate explicitly with
+          # `compgen -G` (which handles "no matches" without erroring under
+          # `set -e`) and push each file individually. `--skip-duplicate`
+          # keeps the job idempotent across retries.
           mapfile -t PKGS < <(compgen -G "./artifacts/*.nupkg" || true)
           if [ "${#PKGS[@]}" -eq 0 ]; then
             echo "::error::No .nupkg files found in ./artifacts to push."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,15 +213,18 @@ jobs:
         shell: pwsh
         run: dotnet tool install --global sign --version ${{ vars.SIGN_TOOL_VERSION || '0.9.1-beta.24469.1' }}
 
-      - name: Sign nupkg(s)
+      - name: Sign nupkg + snupkg
         shell: pwsh
         run: |
+          # Sign both the main package and the symbol package — consumers
+          # who download .snupkg for SourceLink debugging deserve the same
+          # provenance guarantees as the .nupkg they reference.
           sign code trusted-signing `
             --trusted-signing-endpoint "${{ vars.TRUSTED_SIGNING_ENDPOINT }}" `
             --trusted-signing-account "${{ vars.TRUSTED_SIGNING_ACCOUNT }}" `
             --trusted-signing-certificate-profile "${{ vars.TRUSTED_SIGNING_PROFILE }}" `
             --base-directory "$(Get-Location)\artifacts" `
-            "*.nupkg"
+            "*.nupkg" "*.snupkg"
 
       - name: Extract signing leaf cert
         id: extract-cert
@@ -425,15 +428,18 @@ jobs:
         shell: pwsh
         run: dotnet tool install --global sign --version ${{ vars.SIGN_TOOL_VERSION || '0.9.1-beta.24469.1' }}
 
-      - name: Sign nupkg(s)
+      - name: Sign nupkg + snupkg
         shell: pwsh
         run: |
+          # Sign both the main package and the symbol package — consumers
+          # who download .snupkg for SourceLink debugging deserve the same
+          # provenance guarantees as the .nupkg they reference.
           sign code trusted-signing `
             --trusted-signing-endpoint "${{ vars.TRUSTED_SIGNING_ENDPOINT }}" `
             --trusted-signing-account "${{ vars.TRUSTED_SIGNING_ACCOUNT }}" `
             --trusted-signing-certificate-profile "${{ vars.TRUSTED_SIGNING_PROFILE }}" `
             --base-directory "$(Get-Location)\artifacts" `
-            "*.nupkg"
+            "*.nupkg" "*.snupkg"
 
       - name: Extract signing leaf cert
         id: extract-cert

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
 
     outputs:
       version: ${{ steps.version.outputs.version }}
-      cert-uploaded: ${{ steps.extract-cert.outcome }}
 
     steps:
       - name: Checkout
@@ -226,10 +225,10 @@ jobs:
 
       - name: Extract signing leaf cert
         id: extract-cert
-        # Non-blocking: cert extraction is a recovery aid. If parsing the
-        # .signature.p7s ever fails the .cer upload below is skipped, but
-        # the signed .nupkg is still uploaded so the publish job can proceed.
-        continue-on-error: true
+        # Required: the .cer is the artifact a human reviewer downloads to
+        # verify the signing leaf before approving the publish job. If
+        # extraction fails the whole publish must fail — we don't want to
+        # ship to nuget.org without the operator having a chance to verify.
         shell: pwsh
         run: ./eng/Extract-SigningLeafCert.ps1 -ArtifactsDir './artifacts' -Version '${{ steps.version.outputs.version }}'
 
@@ -241,7 +240,6 @@ jobs:
           retention-days: 90
 
       - name: Upload signing certificate artifact
-        if: ${{ steps.extract-cert.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signing-cert-${{ steps.version.outputs.version }}
@@ -277,6 +275,12 @@ jobs:
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: published-${{ needs.sign-rc.outputs.version }}
+          path: ./artifacts
+
+      - name: Download signing cert artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: signing-cert-${{ needs.sign-rc.outputs.version }}
           path: ./artifacts
 
       # ----- NuGet Trusted Publishing (OIDC, no API key) -----
@@ -331,7 +335,6 @@ jobs:
 
     outputs:
       version: ${{ steps.version.outputs.version }}
-      cert-uploaded: ${{ steps.extract-cert.outcome }}
 
     steps:
       - name: Checkout
@@ -418,10 +421,10 @@ jobs:
 
       - name: Extract signing leaf cert
         id: extract-cert
-        # Non-blocking: cert extraction is a recovery aid. If parsing the
-        # .signature.p7s ever fails the .cer upload below is skipped, but
-        # the signed .nupkg is still uploaded so the publish job can proceed.
-        continue-on-error: true
+        # Required: the .cer is the artifact a human reviewer downloads to
+        # verify the signing leaf before approving the publish job. If
+        # extraction fails the whole publish must fail — we don't want to
+        # ship to nuget.org without the operator having a chance to verify.
         shell: pwsh
         run: ./eng/Extract-SigningLeafCert.ps1 -ArtifactsDir './artifacts' -Version '${{ steps.version.outputs.version }}'
 
@@ -433,7 +436,6 @@ jobs:
           retention-days: 90
 
       - name: Upload signing certificate artifact
-        if: ${{ steps.extract-cert.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signing-cert-${{ steps.version.outputs.version }}
@@ -446,19 +448,21 @@ jobs:
   # in the run UI: download the signing-cert artifact, archive/verify it,
   # then click Approve to push to nuget.org and create the GitHub Release.
   #
-  # ⚠️ INFRA SETUP REQUIRED before this job can succeed:
+  # ⚠️ REQUIRED infra setup before this job can succeed:
   #   1. Create GitHub environment `release-publish` (Settings → Environments)
-  #      with a required reviewer (the user who approves stable releases).
-  #   2. Add an Azure federated credential with subject
-  #        repo:jamesconsultingllc/AspectCentral.DispatchProxy:environment:release-publish
-  #      (issuer https://token.actions.githubusercontent.com,
-  #       audience api://AzureADTokenExchange).
-  #      This is only needed if you ever extend this job with Azure auth;
-  #      currently it doesn't, but adding the cred is harmless and future-proofs.
-  #   3. Add a NuGet.org Trusted Publishing policy whose subject claim
+  #      with a required reviewer (the user who approves releases).
+  #   2. Add a NuGet.org Trusted Publishing policy whose subject claim
   #      matches the new environment (or update the existing policy from
   #      `environment:release` to allow both `release` and `release-publish`).
   #      Without this update the `dotnet nuget push` call will return 401.
+  #
+  # Optional / future:
+  #   * Add an Azure federated credential with subject
+  #       repo:jamesconsultingllc/AspectCentral.DispatchProxy:environment:release-publish
+  #     (issuer https://token.actions.githubusercontent.com, audience
+  #     api://AzureADTokenExchange) ONLY if a future iteration of this job
+  #     needs to call Azure (e.g., adding Trusted Signing here too). Today
+  #     this job has no Azure auth, so the credential is not required.
   # ─────────────────────────────────────────────────────────────────────────
   publish-stable:
     name: Publish Stable (gated)
@@ -489,11 +493,7 @@ jobs:
           name: published-${{ needs.sign-stable.outputs.version }}
           path: ./artifacts
 
-      - name: Download signing cert artifact (best-effort)
-        # If sign-stable's cert extraction failed there is no artifact to
-        # download. Don't fail the publish over that — the .nupkg is signed
-        # regardless and is the canonical recovery artifact.
-        if: ${{ needs.sign-stable.outputs.cert-uploaded == 'success' }}
+      - name: Download signing cert artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: signing-cert-${{ needs.sign-stable.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,11 @@ jobs:
         run: ./eng/Extract-SigningLeafCert.ps1 -ArtifactsDir './artifacts' -Version '${{ steps.version.outputs.version }}'
 
       - name: Upload signed package artifact
+        # Always upload the signed nupkg so it is available for diagnosis
+        # even when extraction fails. The publish job still won't run on
+        # failure (`needs:` propagates the job-level failure), but humans
+        # can download the .nupkg from this job's artifacts to debug.
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: published-${{ steps.version.outputs.version }}
@@ -240,6 +245,9 @@ jobs:
           retention-days: 90
 
       - name: Upload signing certificate artifact
+        # Cert upload is gated on extraction success — if extraction failed
+        # there is no signing-cert-*.cer to upload.
+        if: ${{ steps.extract-cert.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signing-cert-${{ steps.version.outputs.version }}
@@ -429,6 +437,11 @@ jobs:
         run: ./eng/Extract-SigningLeafCert.ps1 -ArtifactsDir './artifacts' -Version '${{ steps.version.outputs.version }}'
 
       - name: Upload signed package artifact
+        # Always upload the signed nupkg so it is available for diagnosis
+        # even when extraction fails. The publish job still won't run on
+        # failure (`needs:` propagates the job-level failure), but humans
+        # can download the .nupkg from this job's artifacts to debug.
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: published-${{ steps.version.outputs.version }}
@@ -436,6 +449,9 @@ jobs:
           retention-days: 90
 
       - name: Upload signing certificate artifact
+        # Cert upload is gated on extraction success — if extraction failed
+        # there is no signing-cert-*.cer to upload.
+        if: ${{ steps.extract-cert.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signing-cert-${{ steps.version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,11 +241,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signed-${{ steps.version.outputs.version }}
-          # Include symbol package (snupkg) so SourceLink debugging works for
-          # consumers; the publish job pushes both .nupkg and .snupkg.
-          path: |
-            ./artifacts/*.nupkg
-            ./artifacts/*.snupkg
+          # Only the signed .nupkg ships under this artifact name. Trusted
+          # Signing here covers .nupkg only (matching every prior release on
+          # nuget.org), so we deliberately do not bundle .snupkg under a name
+          # that implies the contents are signed.
+          path: ./artifacts/*.nupkg
           retention-days: 90
 
       - name: Upload signing certificate artifact
@@ -314,13 +314,12 @@ jobs:
           # `compgen -G` (which handles "no matches" without erroring under
           # `set -e`) and push each file individually. `--skip-duplicate`
           # keeps the job idempotent across retries.
-          # Push both the main package and the symbol package. When you push
-          # a .nupkg with a sibling .snupkg present, NuGet auto-uploads the
-          # symbols too, but we enumerate explicitly so the run logs which
-          # files were submitted. --skip-duplicate keeps retries idempotent.
-          mapfile -t PKGS < <(compgen -G "./artifacts/*.nupkg" || true; compgen -G "./artifacts/*.snupkg" || true)
+          # Push the main package. Enumerate via `compgen -G` (which handles
+          # "no matches" without erroring under `set -e`). --skip-duplicate
+          # keeps retries idempotent.
+          mapfile -t PKGS < <(compgen -G "./artifacts/*.nupkg" || true)
           if [ "${#PKGS[@]}" -eq 0 ]; then
-            echo "::error::No .nupkg or .snupkg files found in ./artifacts to push."
+            echo "::error::No .nupkg files found in ./artifacts to push."
             exit 1
           fi
           for pkg in "${PKGS[@]}"; do
@@ -453,11 +452,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: signed-${{ steps.version.outputs.version }}
-          # Include symbol package (snupkg) so SourceLink debugging works for
-          # consumers; the publish job pushes both .nupkg and .snupkg.
-          path: |
-            ./artifacts/*.nupkg
-            ./artifacts/*.snupkg
+          # Only the signed .nupkg ships under this artifact name. Trusted
+          # Signing here covers .nupkg only (matching every prior release on
+          # nuget.org), so we deliberately do not bundle .snupkg under a name
+          # that implies the contents are signed.
+          path: ./artifacts/*.nupkg
           retention-days: 90
 
       - name: Upload signing certificate artifact
@@ -537,13 +536,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Push both the main package and the symbol package. When you push
-          # a .nupkg with a sibling .snupkg present, NuGet auto-uploads the
-          # symbols too, but we enumerate explicitly so the run logs which
-          # files were submitted. --skip-duplicate keeps retries idempotent.
-          mapfile -t PKGS < <(compgen -G "./artifacts/*.nupkg" || true; compgen -G "./artifacts/*.snupkg" || true)
+          # Push the main package. Enumerate via `compgen -G` (which handles
+          # "no matches" without erroring under `set -e`). --skip-duplicate
+          # keeps retries idempotent.
+          mapfile -t PKGS < <(compgen -G "./artifacts/*.nupkg" || true)
           if [ "${#PKGS[@]}" -eq 0 ]; then
-            echo "::error::No .nupkg or .snupkg files found in ./artifacts to push."
+            echo "::error::No .nupkg files found in ./artifacts to push."
             exit 1
           fi
           for pkg in "${PKGS[@]}"; do
@@ -560,5 +558,4 @@ jobs:
           generate_release_notes: true
           files: |
             ./artifacts/*.nupkg
-            ./artifacts/*.snupkg
             ./artifacts/signing-cert-*.cer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,8 +240,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: published-${{ steps.version.outputs.version }}
-          path: ./artifacts/*.nupkg
+          name: signed-${{ steps.version.outputs.version }}
+          # Include symbol package (snupkg) so SourceLink debugging works for
+          # consumers; the publish job pushes both .nupkg and .snupkg.
+          path: |
+            ./artifacts/*.nupkg
+            ./artifacts/*.snupkg
           retention-days: 90
 
       - name: Upload signing certificate artifact
@@ -282,7 +286,7 @@ jobs:
       - name: Download signed package artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: published-${{ needs.sign-rc.outputs.version }}
+          name: signed-${{ needs.sign-rc.outputs.version }}
           path: ./artifacts
 
       - name: Download signing cert artifact
@@ -310,12 +314,16 @@ jobs:
           # `compgen -G` (which handles "no matches" without erroring under
           # `set -e`) and push each file individually. `--skip-duplicate`
           # keeps the job idempotent across retries.
-          mapfile -t NUPKGS < <(compgen -G "./artifacts/*.nupkg" || true)
-          if [ "${#NUPKGS[@]}" -eq 0 ]; then
-            echo "::error::No .nupkg files found in ./artifacts to push."
+          # Push both the main package and the symbol package. When you push
+          # a .nupkg with a sibling .snupkg present, NuGet auto-uploads the
+          # symbols too, but we enumerate explicitly so the run logs which
+          # files were submitted. --skip-duplicate keeps retries idempotent.
+          mapfile -t PKGS < <(compgen -G "./artifacts/*.nupkg" || true; compgen -G "./artifacts/*.snupkg" || true)
+          if [ "${#PKGS[@]}" -eq 0 ]; then
+            echo "::error::No .nupkg or .snupkg files found in ./artifacts to push."
             exit 1
           fi
-          for pkg in "${NUPKGS[@]}"; do
+          for pkg in "${PKGS[@]}"; do
             dotnet nuget push "$pkg" \
               --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
               --source https://api.nuget.org/v3/index.json \
@@ -444,8 +452,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: published-${{ steps.version.outputs.version }}
-          path: ./artifacts/*.nupkg
+          name: signed-${{ steps.version.outputs.version }}
+          # Include symbol package (snupkg) so SourceLink debugging works for
+          # consumers; the publish job pushes both .nupkg and .snupkg.
+          path: |
+            ./artifacts/*.nupkg
+            ./artifacts/*.snupkg
           retention-days: 90
 
       - name: Upload signing certificate artifact
@@ -506,7 +518,7 @@ jobs:
       - name: Download signed package artifact
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
-          name: published-${{ needs.sign-stable.outputs.version }}
+          name: signed-${{ needs.sign-stable.outputs.version }}
           path: ./artifacts
 
       - name: Download signing cert artifact
@@ -525,12 +537,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t NUPKGS < <(compgen -G "./artifacts/*.nupkg" || true)
-          if [ "${#NUPKGS[@]}" -eq 0 ]; then
-            echo "::error::No .nupkg files found in ./artifacts to push."
+          # Push both the main package and the symbol package. When you push
+          # a .nupkg with a sibling .snupkg present, NuGet auto-uploads the
+          # symbols too, but we enumerate explicitly so the run logs which
+          # files were submitted. --skip-duplicate keeps retries idempotent.
+          mapfile -t PKGS < <(compgen -G "./artifacts/*.nupkg" || true; compgen -G "./artifacts/*.snupkg" || true)
+          if [ "${#PKGS[@]}" -eq 0 ]; then
+            echo "::error::No .nupkg or .snupkg files found in ./artifacts to push."
             exit 1
           fi
-          for pkg in "${NUPKGS[@]}"; do
+          for pkg in "${PKGS[@]}"; do
             dotnet nuget push "$pkg" \
               --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
               --source https://api.nuget.org/v3/index.json \
@@ -544,4 +560,5 @@ jobs:
           generate_release_notes: true
           files: |
             ./artifacts/*.nupkg
+            ./artifacts/*.snupkg
             ./artifacts/signing-cert-*.cer


### PR DESCRIPTION
## What

Adds a manual approval gate between **sign** and **publish** for both RC and stable releases so the signing leaf cert can be verified before any package ships to nuget.org.

## Flow

| Trigger | Sign job (env: `release`) | Publish job (env: `release-publish`, **gated**) |
|---|---|---|
| push to `release/**` | `sign-rc` — pack + Trusted Signing + upload nupkg & .cer | `publish-rc` — download + nuget push |
| push tag `v*` | `sign-stable` — pack + Trusted Signing + upload nupkg & .cer | `publish-stable` — download + nuget push + GitHub Release |

After the sign job completes the run pauses with **Review deployments**. Open the run, download `signing-cert-<version>`, verify the leaf fingerprint against the expected cert, then **Approve** to publish — or **Reject** to cancel (package never hits nuget.org).

## Why

Catches a wrong/unexpected leaf cert (Trusted Signing rotates) before it is permanently published. Also lets us archive the cert artifact wherever we want before the publish proceeds.

## Infra setup needed before merge can ship a package

1. Create GitHub environment **`release-publish`** (Settings → Environments) with a **required reviewer** (you).
2. Add a NuGet.org Trusted Publishing policy whose subject claim matches  `repo:jamesconsultingllc/AspectCentral.DispatchProxy:environment:release-publish`  (or update the existing policy to allow this subject in addition to `environment:release`). Without this, `dotnet nuget push` returns 401.

The Azure federated credential stays scoped to `environment:release` — only the sign jobs talk to Azure Trusted Signing.

## Tests

- `actionlint` clean.
- YAML parses; jobs: `build-test`, `sign-rc`, `publish-rc`, `sign-stable`, `publish-stable`.
- Real validation happens on next `release/**` push (RC) once the env + nuget policy are configured.