### PR TITLE
docs: GitHub Actions badges + raise test coverage to 99.45%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
             --no-build \
             --logger "trx;LogFileName=test-results.trx" \
             --collect:"XPlat Code Coverage" \
+            --settings AspectCentral.DispatchProxy.Tests/coverlet.runsettings \
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
 
       - name: End Sonar analysis

--- a/AspectCentral.DispatchProxy.Tests/ServiceCollectionExtensionsTests.cs
+++ b/AspectCentral.DispatchProxy.Tests/ServiceCollectionExtensionsTests.cs
@@ -239,6 +239,57 @@ public class ServiceCollectionExtensionsTests
         // Should not throw.
         _serviceCollection.AddAspectSupport(_aspectConfigurationProvider);
     }
+
+    [Fact]
+    public void AddAspectSupportThrowsWhenProviderIsRegisteredViaImplementationType()
+    {
+        // A type-registered provider has no ImplementationInstance to compare against, so the
+        // overload that accepts an explicit instance must refuse rather than silently swap which
+        // provider is observed at runtime.
+        _serviceCollection.AddSingleton<IAspectConfigurationProvider, InMemoryAspectConfigurationProvider>();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => _serviceCollection.AddAspectSupport(_aspectConfigurationProvider));
+        Assert.Contains("implementation type or factory", ex.Message);
+    }
+
+    [Fact]
+    public void AddAspectSupportThrowsWhenProviderIsRegisteredViaFactory()
+    {
+        // Same guard as the type-registered case, but for ImplementationFactory descriptors.
+        _serviceCollection.AddSingleton<IAspectConfigurationProvider>(
+            _ => new InMemoryAspectConfigurationProvider());
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => _serviceCollection.AddAspectSupport(_aspectConfigurationProvider));
+        Assert.Contains("implementation type or factory", ex.Message);
+    }
+
+    [Fact]
+    public void AddAspectSupportFluentThrowsWhenProviderIsRegisteredViaImplementationType()
+    {
+        // The fluent (parameterless) overload walks the collection looking for an existing
+        // singleton instance it can reuse; encountering a type-registered provider means there is
+        // no concrete instance available, and reusing it would silently change which provider
+        // ConfigureAspects rewrites against.
+        _serviceCollection.AddSingleton<IAspectConfigurationProvider, InMemoryAspectConfigurationProvider>();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => _serviceCollection.AddAspectSupport());
+        Assert.Contains("without a singleton instance", ex.Message);
+    }
+
+    [Fact]
+    public void AddAspectSupportFluentThrowsWhenProviderIsRegisteredViaFactory()
+    {
+        // Same guard for ImplementationFactory descriptors in the fluent path.
+        _serviceCollection.AddSingleton<IAspectConfigurationProvider>(
+            _ => new InMemoryAspectConfigurationProvider());
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => _serviceCollection.AddAspectSupport());
+        Assert.Contains("without a singleton instance", ex.Message);
+    }
 }
 
 internal interface IGenericService<T>

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
@@ -21,17 +21,20 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
 {
     /// <summary>
     /// When <see langword="true" />, <see cref="PreInvoke" /> sets
-    /// <see cref="AspectContext.ReturnValue" /> to a non-generic <see cref="Task" /> that is
-    /// guaranteed to still be pending when <c>BaseAspect.HandleAsyncShortCircuit</c> attaches
-    /// its <see cref="Task.ContinueWith(System.Action{Task})" /> continuation. This is what
-    /// forces the continuation to be scheduled on a worker (rather than running inline at
-    /// registration time on an already-completed task) and unambiguously exercises the
-    /// non-generic short-circuit branch.
+    /// <see cref="AspectContext.ReturnValue" /> to a <see cref="Task.Delay(int)" /> Task
+    /// that is observably pending for a measurable window. <c>Task.Delay</c> is timer-backed
+    /// and cannot complete until at least its delay has elapsed, so the Task is guaranteed
+    /// to still be pending when <c>BaseAspect.HandleAsyncShortCircuit</c> attaches its
+    /// <see cref="Task.ContinueWith(System.Action{Task})" /> continuation (which is
+    /// configured with <c>ExecuteSynchronously</c>). That forces the continuation to be
+    /// scheduled rather than running inline at registration time on an already-completed
+    /// task, and unambiguously exercises the non-generic short-circuit branch.
     /// <para>
-    /// A <see cref="TaskCompletionSource" /> is used (rather than <see cref="Task.Run" /> or
-    /// <see cref="Task.CompletedTask" />) because both of those can be observably complete by
-    /// the time <c>HandleAsyncShortCircuit</c> attaches its continuation, allowing the
-    /// continuation to run inline and reintroducing the original coverage-attribution flake.
+    /// <see cref="Task.Run(System.Action)" />, <see cref="Task.CompletedTask" />, and a
+    /// <see cref="TaskCompletionSource" /> completed from a thread-pool worker are all
+    /// deliberately avoided here: each can be observably complete by the time
+    /// <c>ContinueWith</c> is reached, allowing the continuation to run inline and
+    /// reintroducing the original coverage-attribution flake.
     /// </para>
     /// When <see langword="false" />, <see cref="PreInvoke" /> leaves ReturnValue at its default
     /// to exercise the sync short-circuit / fallback PostInvoke path.
@@ -61,16 +64,17 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
         aspectContext.InvokeMethod = false;
         if (!SupplyNonGenericTask) return;
 
-        var tcs = new TaskCompletionSource();
-        // Complete the task on a thread-pool worker after PreInvoke returns, so the Task
-        // is observably pending at the moment BaseAspect.HandleAsyncShortCircuit attaches
-        // its ContinueWith continuation. This is what guarantees the continuation is
-        // scheduled (rather than running inline at registration time on an already-
-        // completed task) and is what the NonGenericTaskShortCircuit coverage test depends
-        // on. Task.Run / Task.CompletedTask can both be observably complete by the time
-        // ContinueWith runs and would reintroduce the inline-execution race.
-        _ = Task.Run(tcs.SetResult);
-        aspectContext.ReturnValue = tcs.Task;
+        // Hand BaseAspect a Task that is observably pending for a measurable window
+        // (Task.Delay returns a timer-backed Task that cannot complete until at least
+        // its delay has elapsed). This guarantees the Task is still pending when
+        // BaseAspect.HandleAsyncShortCircuit attaches its ContinueWith continuation,
+        // even though that continuation is configured with ExecuteSynchronously, so the
+        // continuation cannot run inline at registration time.
+        //
+        // Task.Run / Task.CompletedTask / a TaskCompletionSource completed from a
+        // thread-pool worker can all be observably complete by the time ContinueWith
+        // runs and would reintroduce the inline-execution race.
+        aspectContext.ReturnValue = Task.Delay(50);
     }
 
     /// <inheritdoc />

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
@@ -21,8 +21,13 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
 {
     /// <summary>
     /// When <see langword="true" />, <see cref="PreInvoke" /> sets
-    /// <see cref="AspectContext.ReturnValue" /> to <see cref="Task.CompletedTask" /> (a
-    /// non-generic <see cref="Task" />) to exercise the non-generic Task short-circuit path.
+    /// <see cref="AspectContext.ReturnValue" /> to a freshly scheduled non-generic
+    /// <see cref="Task" /> (via <see cref="Task.Run(System.Action)" />) to exercise the
+    /// non-generic Task short-circuit path in <c>BaseAspect.HandleAsyncShortCircuit</c>.
+    /// <see cref="Task.CompletedTask" /> is deliberately avoided here: the runtime's cached
+    /// completed-task singleton hits a fast-path in the awaiter machinery that bypasses the
+    /// <c>ContinueWith</c> lambda the test is meant to cover, leaving those lines unhit by
+    /// coverage. A real scheduled Task forces the continuation to execute.
     /// When <see langword="false" />, <see cref="PreInvoke" /> leaves ReturnValue at its default
     /// to exercise the sync short-circuit / fallback PostInvoke path.
     /// </summary>

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
@@ -22,9 +22,10 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
     /// <summary>
     /// When non-<see langword="null" />, <see cref="PreInvoke" /> assigns this task to
     /// <see cref="AspectContext.ReturnValue" /> to exercise the non-generic Task short-circuit
-    /// branch of <c>BaseAspect.HandleAsyncShortCircuit</c>. Use a <see cref="TaskCompletionSource" />
-    /// (non-generic) to obtain a non-generic <see cref="Task" />; <c>Task.CompletedTask</c> is
-    /// internally a <c>Task&lt;VoidTaskResult&gt;</c> and would route through the generic branch.
+    /// branch of <see cref="BaseAspect{T}.HandleAsyncShortCircuit" />. Use a
+    /// <see cref="TaskCompletionSource" /> (non-generic) to obtain a non-generic
+    /// <see cref="Task" />; <c>Task.CompletedTask</c> is internally a
+    /// <c>Task&lt;VoidTaskResult&gt;</c> and would route through the generic branch.
     /// When <see langword="null" />, <see cref="PreInvoke" /> leaves <c>ReturnValue</c> at its
     /// default to exercise the sync short-circuit / fallback <c>PostInvoke</c> path.
     /// </summary>

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
@@ -20,19 +20,15 @@ namespace AspectCentral.DispatchProxy.Tests;
 public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
 {
     /// <summary>
-    /// When <see langword="true" />, <see cref="PreInvoke" /> sets
-    /// <see cref="AspectContext.ReturnValue" /> to a true non-generic <see cref="Task" />
-    /// (the runtime's <c>Task.CompletedTask</c> is actually a <c>Task&lt;VoidTaskResult&gt;</c>
-    /// and would route through the generic branch, which is why it cannot be used here) to
-    /// exercise the non-generic Task short-circuit branch of
-    /// <c>BaseAspect.HandleAsyncShortCircuit</c>. The production code wraps the supplied
-    /// task in <see cref="BaseAspectAsyncProcessor.ProcessActionAsync" /> and assigns the
-    /// wrapper back to <see cref="AspectContext.ReturnValue" />, so the caller's <c>await</c>
-    /// deterministically observes <see cref="PostInvoke" /> having run.
-    /// When <see langword="false" />, <see cref="PreInvoke" /> leaves ReturnValue at its default
-    /// to exercise the sync short-circuit / fallback PostInvoke path.
+    /// When non-<see langword="null" />, <see cref="PreInvoke" /> assigns this task to
+    /// <see cref="AspectContext.ReturnValue" /> to exercise the non-generic Task short-circuit
+    /// branch of <c>BaseAspect.HandleAsyncShortCircuit</c>. Use a <see cref="TaskCompletionSource" />
+    /// (non-generic) to obtain a non-generic <see cref="Task" />; <c>Task.CompletedTask</c> is
+    /// internally a <c>Task&lt;VoidTaskResult&gt;</c> and would route through the generic branch.
+    /// When <see langword="null" />, <see cref="PreInvoke" /> leaves <c>ReturnValue</c> at its
+    /// default to exercise the sync short-circuit / fallback <c>PostInvoke</c> path.
     /// </summary>
-    public static bool SupplyNonGenericTask { get; set; }
+    public static Task? SuppliedTask { get; set; }
 
     /// <summary>Records that PostInvoke ran.</summary>
     public static bool PostInvokeRan { get; set; }
@@ -55,15 +51,7 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
     public override void PreInvoke(AspectContext aspectContext)
     {
         aspectContext.InvokeMethod = false;
-        if (!SupplyNonGenericTask) return;
-
-        // Task.Delay returns a true non-generic Task (not a Task<VoidTaskResult>), which is
-        // what's required to exercise the non-generic branch of
-        // BaseAspect.HandleAsyncShortCircuit. Task.CompletedTask is internally a
-        // Task<VoidTaskResult> and would route through the generic branch instead.
-        // Task.Delay is timer-backed (not thread-pool scheduled), so it is deterministically
-        // pending when HandleAsyncShortCircuit observes it.
-        aspectContext.ReturnValue = Task.Delay(1);
+        if (SuppliedTask is not null) aspectContext.ReturnValue = SuppliedTask;
     }
 
     /// <inheritdoc />

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
@@ -49,7 +49,7 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
     public override void PreInvoke(AspectContext aspectContext)
     {
         aspectContext.InvokeMethod = false;
-        if (SupplyNonGenericTask) aspectContext.ReturnValue = Task.CompletedTask;
+        if (SupplyNonGenericTask) aspectContext.ReturnValue = Task.Run(() => { });
     }
 
     /// <inheritdoc />

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
@@ -23,11 +23,14 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
     /// When <see langword="true" />, <see cref="PreInvoke" /> sets
     /// <see cref="AspectContext.ReturnValue" /> to a freshly scheduled non-generic
     /// <see cref="Task" /> (via <see cref="Task.Run(System.Action)" />) to exercise the
-    /// non-generic Task short-circuit path in <c>BaseAspect.HandleAsyncShortCircuit</c>.
-    /// <see cref="Task.CompletedTask" /> is deliberately avoided here: the runtime's cached
-    /// completed-task singleton hits a fast-path in the awaiter machinery that bypasses the
-    /// <c>ContinueWith</c> lambda the test is meant to cover, leaving those lines unhit by
-    /// coverage. A real scheduled Task forces the continuation to execute.
+    /// non-generic Task short-circuit path in <c>BaseAspect.HandleAsyncShortCircuit</c>,
+    /// which schedules <see cref="PostInvoke" /> through <see cref="Task.ContinueWith(System.Action{Task})" />.
+    /// <see cref="Task.CompletedTask" /> is deliberately avoided here: when the captured
+    /// task is already completed, the continuation registered by <c>ContinueWith</c> can
+    /// run inline on the calling thread and coverage tooling has been observed to attribute
+    /// hits to the inlined continuation rather than to the source lines in
+    /// <c>HandleAsyncShortCircuit</c>. A still-pending Task forces the continuation onto a
+    /// thread-pool worker, so the short-circuit branch is unambiguously exercised.
     /// When <see langword="false" />, <see cref="PreInvoke" /> leaves ReturnValue at its default
     /// to exercise the sync short-circuit / fallback PostInvoke path.
     /// </summary>

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
@@ -21,16 +21,18 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
 {
     /// <summary>
     /// When <see langword="true" />, <see cref="PreInvoke" /> sets
-    /// <see cref="AspectContext.ReturnValue" /> to a freshly scheduled non-generic
-    /// <see cref="Task" /> (via <see cref="Task.Run(System.Action)" />) to exercise the
-    /// non-generic Task short-circuit path in <c>BaseAspect.HandleAsyncShortCircuit</c>,
-    /// which schedules <see cref="PostInvoke" /> through <see cref="Task.ContinueWith(System.Action{Task})" />.
-    /// <see cref="Task.CompletedTask" /> is deliberately avoided here: when the captured
-    /// task is already completed, the continuation registered by <c>ContinueWith</c> can
-    /// run inline on the calling thread and coverage tooling has been observed to attribute
-    /// hits to the inlined continuation rather than to the source lines in
-    /// <c>HandleAsyncShortCircuit</c>. A still-pending Task forces the continuation onto a
-    /// thread-pool worker, so the short-circuit branch is unambiguously exercised.
+    /// <see cref="AspectContext.ReturnValue" /> to a non-generic <see cref="Task" /> that is
+    /// guaranteed to still be pending when <c>BaseAspect.HandleAsyncShortCircuit</c> attaches
+    /// its <see cref="Task.ContinueWith(System.Action{Task})" /> continuation. This is what
+    /// forces the continuation to be scheduled on a worker (rather than running inline at
+    /// registration time on an already-completed task) and unambiguously exercises the
+    /// non-generic short-circuit branch.
+    /// <para>
+    /// A <see cref="TaskCompletionSource" /> is used (rather than <see cref="Task.Run" /> or
+    /// <see cref="Task.CompletedTask" />) because both of those can be observably complete by
+    /// the time <c>HandleAsyncShortCircuit</c> attaches its continuation, allowing the
+    /// continuation to run inline and reintroducing the original coverage-attribution flake.
+    /// </para>
     /// When <see langword="false" />, <see cref="PreInvoke" /> leaves ReturnValue at its default
     /// to exercise the sync short-circuit / fallback PostInvoke path.
     /// </summary>
@@ -57,7 +59,18 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
     public override void PreInvoke(AspectContext aspectContext)
     {
         aspectContext.InvokeMethod = false;
-        if (SupplyNonGenericTask) aspectContext.ReturnValue = Task.Run(() => { });
+        if (!SupplyNonGenericTask) return;
+
+        var tcs = new TaskCompletionSource();
+        // Complete the task on a thread-pool worker after PreInvoke returns, so the Task
+        // is observably pending at the moment BaseAspect.HandleAsyncShortCircuit attaches
+        // its ContinueWith continuation. This is what guarantees the continuation is
+        // scheduled (rather than running inline at registration time on an already-
+        // completed task) and is what the NonGenericTaskShortCircuit coverage test depends
+        // on. Task.Run / Task.CompletedTask can both be observably complete by the time
+        // ContinueWith runs and would reintroduce the inline-execution race.
+        _ = Task.Run(tcs.SetResult);
+        aspectContext.ReturnValue = tcs.Task;
     }
 
     /// <inheritdoc />

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
@@ -21,21 +21,14 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
 {
     /// <summary>
     /// When <see langword="true" />, <see cref="PreInvoke" /> sets
-    /// <see cref="AspectContext.ReturnValue" /> to a <see cref="Task.Delay(int)" /> Task
-    /// that is observably pending for a measurable window. <c>Task.Delay</c> is timer-backed
-    /// and cannot complete until at least its delay has elapsed, so the Task is guaranteed
-    /// to still be pending when <c>BaseAspect.HandleAsyncShortCircuit</c> attaches its
-    /// <see cref="Task.ContinueWith(System.Action{Task})" /> continuation (which is
-    /// configured with <c>ExecuteSynchronously</c>). That forces the continuation to be
-    /// scheduled rather than running inline at registration time on an already-completed
-    /// task, and unambiguously exercises the non-generic short-circuit branch.
-    /// <para>
-    /// <see cref="Task.Run(System.Action)" />, <see cref="Task.CompletedTask" />, and a
-    /// <see cref="TaskCompletionSource" /> completed from a thread-pool worker are all
-    /// deliberately avoided here: each can be observably complete by the time
-    /// <c>ContinueWith</c> is reached, allowing the continuation to run inline and
-    /// reintroducing the original coverage-attribution flake.
-    /// </para>
+    /// <see cref="AspectContext.ReturnValue" /> to a true non-generic <see cref="Task" />
+    /// (the runtime's <c>Task.CompletedTask</c> is actually a <c>Task&lt;VoidTaskResult&gt;</c>
+    /// and would route through the generic branch, which is why it cannot be used here) to
+    /// exercise the non-generic Task short-circuit branch of
+    /// <c>BaseAspect.HandleAsyncShortCircuit</c>. The production code wraps the supplied
+    /// task in <see cref="BaseAspectAsyncProcessor.ProcessActionAsync" /> and assigns the
+    /// wrapper back to <see cref="AspectContext.ReturnValue" />, so the caller's <c>await</c>
+    /// deterministically observes <see cref="PostInvoke" /> having run.
     /// When <see langword="false" />, <see cref="PreInvoke" /> leaves ReturnValue at its default
     /// to exercise the sync short-circuit / fallback PostInvoke path.
     /// </summary>
@@ -64,17 +57,11 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
         aspectContext.InvokeMethod = false;
         if (!SupplyNonGenericTask) return;
 
-        // Hand BaseAspect a Task that is observably pending for a measurable window
-        // (Task.Delay returns a timer-backed Task that cannot complete until at least
-        // its delay has elapsed). This guarantees the Task is still pending when
-        // BaseAspect.HandleAsyncShortCircuit attaches its ContinueWith continuation,
-        // even though that continuation is configured with ExecuteSynchronously, so the
-        // continuation cannot run inline at registration time.
-        //
-        // Task.Run / Task.CompletedTask / a TaskCompletionSource completed from a
-        // thread-pool worker can all be observably complete by the time ContinueWith
-        // runs and would reintroduce the inline-execution race.
-        aspectContext.ReturnValue = Task.Delay(50);
+        // Task.Run(Action) returns a true non-generic Task (not a Task<VoidTaskResult>),
+        // which is what's required to exercise the non-generic branch of
+        // BaseAspect.HandleAsyncShortCircuit. Task.CompletedTask is internally a
+        // Task<VoidTaskResult> and would route through the generic branch instead.
+        aspectContext.ReturnValue = Task.Run(() => { });
     }
 
     /// <inheritdoc />

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspect.cs
@@ -57,11 +57,13 @@ public class ShortCircuitAspect<T> : BaseAspect<T> where T : class?
         aspectContext.InvokeMethod = false;
         if (!SupplyNonGenericTask) return;
 
-        // Task.Run(Action) returns a true non-generic Task (not a Task<VoidTaskResult>),
-        // which is what's required to exercise the non-generic branch of
+        // Task.Delay returns a true non-generic Task (not a Task<VoidTaskResult>), which is
+        // what's required to exercise the non-generic branch of
         // BaseAspect.HandleAsyncShortCircuit. Task.CompletedTask is internally a
         // Task<VoidTaskResult> and would route through the generic branch instead.
-        aspectContext.ReturnValue = Task.Run(() => { });
+        // Task.Delay is timer-backed (not thread-pool scheduled), so it is deterministically
+        // pending when HandleAsyncShortCircuit observes it.
+        aspectContext.ReturnValue = Task.Delay(1);
     }
 
     /// <inheritdoc />

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspectTests.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspectTests.cs
@@ -58,18 +58,25 @@ public class ShortCircuitAspectTests
 
     /// <summary>
     /// Async method returning <see cref="Task" /> (non-generic), InvokeMethod=false,
-    /// non-generic Task supplied — exercises the <c>ContinueWith</c> branch of
-    /// <c>HandleAsyncShortCircuit</c>.
+    /// non-generic Task supplied — exercises the wrapped <see cref="Task" /> branch of
+    /// <c>HandleAsyncShortCircuit</c> and verifies its contract: the caller's <c>await</c>
+    /// must not complete until <c>PostInvoke</c> has run. Before the fix this branch did a
+    /// fire-and-forget <c>ContinueWith</c> and returned the original task, letting the
+    /// caller's continuation race <c>PostInvoke</c>.
     /// </summary>
     [Fact]
-    public async Task NonGenericTaskShortCircuit_RunsPostInvoke()
+    public async Task NonGenericTaskShortCircuit_RunsPostInvokeBeforeReturnedTaskCompletes()
     {
         ShortCircuitAspect<ITestInterface>.SupplyNonGenericTask = true;
         ShortCircuitAspect<ITestInterface>.PostInvokeRan = false;
 
         var proxy = CreateProxy();
-        await proxy.TestAsync(1, "x", new MyUnitTestClass(1, "x"));
+        var returned = proxy.TestAsync(1, "x", new MyUnitTestClass(1, "x"));
 
+        // Contract: the returned task must not complete until PostInvoke has run.
+        await returned;
+
+        Assert.True(returned.IsCompletedSuccessfully);
         Assert.True(ShortCircuitAspect<ITestInterface>.PostInvokeRan);
     }
 }

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspectTests.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspectTests.cs
@@ -47,7 +47,7 @@ public class ShortCircuitAspectTests
     [Fact]
     public void SyncShortCircuit_RunsPostInvoke()
     {
-        ShortCircuitAspect<ITestInterface>.SupplyNonGenericTask = false;
+        ShortCircuitAspect<ITestInterface>.SuppliedTask = null;
         ShortCircuitAspect<ITestInterface>.PostInvokeRan = false;
 
         var proxy = CreateProxy();
@@ -58,25 +58,45 @@ public class ShortCircuitAspectTests
 
     /// <summary>
     /// Async method returning <see cref="Task" /> (non-generic), InvokeMethod=false,
-    /// non-generic Task supplied — exercises the wrapped <see cref="Task" /> branch of
-    /// <c>HandleAsyncShortCircuit</c> and verifies its contract: the caller's <c>await</c>
-    /// must not complete until <c>PostInvoke</c> has run. Before the fix this branch did a
-    /// fire-and-forget <c>ContinueWith</c> and returned the original task, letting the
-    /// caller's continuation race <c>PostInvoke</c>.
+    /// non-generic Task supplied — deterministic regression test for the wrapper-task
+    /// contract in <c>HandleAsyncShortCircuit</c>.
+    ///
+    /// The supplied task is a <see cref="TaskCompletionSource" /> (non-generic, so its
+    /// <see cref="Task" /> is a true <see cref="Task" /> rather than a <c>Task&lt;VoidTaskResult&gt;</c>)
+    /// that we hold pending while the proxy is called. The two assertions together pin the
+    /// contract independently of timing:
+    /// <list type="bullet">
+    ///   <item>The returned task is NOT the supplied task. The pre-fix code returned the supplied
+    ///     task verbatim (after attaching a fire-and-forget <c>ContinueWith</c>); the fix returns
+    ///     a distinct wrapper produced by <c>ProcessActionAsync</c>.</item>
+    ///   <item>While the supplied task is still pending, the returned task is also still pending.
+    ///     This rules out the pathological case of the wrapper accidentally completing before the
+    ///     awaited task does.</item>
+    /// </list>
+    /// We then complete the supplied task, await the returned wrapper, and assert PostInvoke ran.
     /// </summary>
     [Fact]
-    public async Task NonGenericTaskShortCircuit_RunsPostInvokeBeforeReturnedTaskCompletes()
+    public async Task NonGenericTaskShortCircuit_ReturnsWrapperThatAwaitsPostInvoke()
     {
-        ShortCircuitAspect<ITestInterface>.SupplyNonGenericTask = true;
+        var tcs = new TaskCompletionSource();
+        ShortCircuitAspect<ITestInterface>.SuppliedTask = tcs.Task;
         ShortCircuitAspect<ITestInterface>.PostInvokeRan = false;
 
         var proxy = CreateProxy();
         var returned = proxy.TestAsync(1, "x", new MyUnitTestClass(1, "x"));
 
-        // Contract: the returned task must not complete until PostInvoke has run.
+        // Contract 1: the proxy hands back a wrapper, not the original supplied task.
+        // (Pre-fix code returned the supplied task verbatim.)
+        Assert.NotSame(tcs.Task, returned);
+        // Contract 2: while the supplied task is pending, the wrapper is pending too.
+        Assert.False(returned.IsCompleted);
+
+        tcs.SetResult();
         await returned;
 
         Assert.True(returned.IsCompletedSuccessfully);
         Assert.True(ShortCircuitAspect<ITestInterface>.PostInvokeRan);
+
+        ShortCircuitAspect<ITestInterface>.SuppliedTask = null;
     }
 }

--- a/AspectCentral.DispatchProxy.Tests/ShortCircuitAspectTests.cs
+++ b/AspectCentral.DispatchProxy.Tests/ShortCircuitAspectTests.cs
@@ -82,21 +82,29 @@ public class ShortCircuitAspectTests
         ShortCircuitAspect<ITestInterface>.SuppliedTask = tcs.Task;
         ShortCircuitAspect<ITestInterface>.PostInvokeRan = false;
 
-        var proxy = CreateProxy();
-        var returned = proxy.TestAsync(1, "x", new MyUnitTestClass(1, "x"));
+        try
+        {
+            var proxy = CreateProxy();
+            var returned = proxy.TestAsync(1, "x", new MyUnitTestClass(1, "x"));
 
-        // Contract 1: the proxy hands back a wrapper, not the original supplied task.
-        // (Pre-fix code returned the supplied task verbatim.)
-        Assert.NotSame(tcs.Task, returned);
-        // Contract 2: while the supplied task is pending, the wrapper is pending too.
-        Assert.False(returned.IsCompleted);
+            // Contract 1: the proxy hands back a wrapper, not the original supplied task.
+            // (Pre-fix code returned the supplied task verbatim.)
+            Assert.NotSame(tcs.Task, returned);
+            // Contract 2: while the supplied task is pending, the wrapper is pending too.
+            Assert.False(returned.IsCompleted);
 
-        tcs.SetResult();
-        await returned;
+            tcs.SetResult();
+            await returned;
 
-        Assert.True(returned.IsCompletedSuccessfully);
-        Assert.True(ShortCircuitAspect<ITestInterface>.PostInvokeRan);
-
-        ShortCircuitAspect<ITestInterface>.SuppliedTask = null;
+            Assert.True(returned.IsCompletedSuccessfully);
+            Assert.True(ShortCircuitAspect<ITestInterface>.PostInvokeRan);
+        }
+        finally
+        {
+            // Reset static state and unblock the TCS even if an assertion above failed,
+            // so a failure here cannot leak state into later tests.
+            ShortCircuitAspect<ITestInterface>.SuppliedTask = null;
+            tcs.TrySetResult();
+        }
     }
 }

--- a/AspectCentral.DispatchProxy.Tests/coverlet.runsettings
+++ b/AspectCentral.DispatchProxy.Tests/coverlet.runsettings
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <!--
+            Exclude Roslyn source-generated files (e.g. the [LoggerMessage] generator
+            output for AspectLogs). These files are not authored code, are 100% owned
+            by the generator, and their unreachable IsEnabled fast-path branches drag
+            down the reported coverage without representing anything we can test.
+          -->
+          <ExcludeByFile>**/obj/**/*.g.cs,**/*.Generated.cs</ExcludeByFile>
+          <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/AspectCentral.DispatchProxy.Tests/coverlet.runsettings
+++ b/AspectCentral.DispatchProxy.Tests/coverlet.runsettings
@@ -2,14 +2,21 @@
 <RunSettings>
   <DataCollectionRunSettings>
     <DataCollectors>
-      <DataCollector friendlyName="XPlat code coverage">
+      <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
-          <Format>cobertura</Format>
+          <!--
+            Format is intentionally omitted. The XPlat Code Coverage data collector
+            defaults to cobertura for local `dotnet test` runs; CI overrides it to
+            opencover via the runsettings command-line override for the Sonar scanner.
+            Pinning a Format here would either lie about what CI actually produces
+            or break the local default.
+          -->
+
           <!--
             Exclude Roslyn source-generated files (e.g. the [LoggerMessage] generator
             output for AspectLogs). These files are not authored code, are 100% owned
             by the generator, and their unreachable IsEnabled fast-path branches drag
-            down the reported coverage without representing anything we can test.
+            down reported coverage without representing anything we can test.
           -->
           <ExcludeByFile>**/obj/**/*.g.cs,**/*.Generated.cs</ExcludeByFile>
           <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>

--- a/AspectCentral.DispatchProxy.Tests/coverlet.runsettings
+++ b/AspectCentral.DispatchProxy.Tests/coverlet.runsettings
@@ -13,10 +13,15 @@
           -->
 
           <!--
-            Exclude Roslyn source-generated files (e.g. the [LoggerMessage] generator
-            output for AspectLogs). These files are not authored code, are 100% owned
-            by the generator, and their unreachable IsEnabled fast-path branches drag
-            down reported coverage without representing anything we can test.
+            Filter compiler- and generator-emitted code out of the coverage report:
+              * ExcludeByFile: Roslyn source-generator output (the [LoggerMessage]
+                generator emits obj/.../LoggerMessage.g.cs). These files are 100% owned
+                by the generator and their unreachable IsEnabled fast-path branches drag
+                down reported coverage without representing anything we can test.
+              * ExcludeByAttribute: any member tagged GeneratedCodeAttribute,
+                CompilerGeneratedAttribute (covers compiler-synthesized closures,
+                state machines, anonymous types, etc.), or ExcludeFromCodeCoverageAttribute
+                (the standard opt-out marker for code that should not be measured).
           -->
           <ExcludeByFile>**/obj/**/*.g.cs,**/*.Generated.cs</ExcludeByFile>
           <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>

--- a/AspectCentral.DispatchProxy/BaseAspect.cs
+++ b/AspectCentral.DispatchProxy/BaseAspect.cs
@@ -63,6 +63,32 @@ internal static class BaseAspectAsyncProcessor
             postInvoke(aspectContext);
         }
     }
+
+    /// <summary>
+    /// Awaits a non-generic <see cref="Task" /> short-circuit result and runs
+    /// <paramref name="postInvoke" /> in a <c>finally</c>. Returning this task from
+    /// <see cref="BaseAspect{T}.HandleAsyncShortCircuit" /> ensures the caller's <c>await</c>
+    /// observes <paramref name="postInvoke" /> having completed before resuming, matching the
+    /// contract of the generic <see cref="ProcessFunctionAsync{TK}" /> path.
+    /// </summary>
+    /// <param name="task">The non-generic task supplied by a short-circuiting aspect.</param>
+    /// <param name="aspectContext">The invocation context passed to <paramref name="postInvoke" />.</param>
+    /// <param name="postInvoke">The post-invocation callback to run after the task completes or faults.</param>
+    /// <returns>A task that completes after both <paramref name="task" /> and <paramref name="postInvoke" /> have run.</returns>
+    public static async Task ProcessActionAsync(
+        Task task,
+        AspectContext aspectContext,
+        Action<AspectContext> postInvoke)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        finally
+        {
+            postInvoke(aspectContext);
+        }
+    }
 }
 
 /// <summary>
@@ -327,7 +353,8 @@ public abstract class BaseAspect<T> : System.Reflection.DispatchProxy where T : 
     /// <summary>
     /// Handles an async short-circuit: routes <see cref="Task{TResult}" /> results through the
     /// generic async processor so <see cref="PostInvoke" /> observes the unwrapped result, and
-    /// attaches a continuation for non-generic <see cref="Task" /> results.
+    /// wraps non-generic <see cref="Task" /> results so <see cref="PostInvoke" /> is awaited as
+    /// part of the returned task's completion.
     /// </summary>
     private void HandleAsyncShortCircuit(AspectContext aspectContext, Task shortCircuitTask)
     {
@@ -345,13 +372,11 @@ public abstract class BaseAspect<T> : System.Reflection.DispatchProxy where T : 
             return;
         }
 
-        // Non-generic Task — no result to unwrap; just attach PostInvoke.
-        var ctx = aspectContext;
-        shortCircuitTask.ContinueWith(
-            _ => PostInvoke(ctx),
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
+        // Non-generic Task — wrap so the caller's await on the returned task observes PostInvoke
+        // having completed before resuming. A fire-and-forget ContinueWith would let the caller's
+        // continuation race PostInvoke, which is the bug this branch previously had.
+        aspectContext.ReturnValue = BaseAspectAsyncProcessor.ProcessActionAsync(
+            shortCircuitTask, aspectContext, PostInvoke);
     }
 
     /// <summary>

--- a/AspectCentral.DispatchProxy/BaseAspect.cs
+++ b/AspectCentral.DispatchProxy/BaseAspect.cs
@@ -66,10 +66,11 @@ internal static class BaseAspectAsyncProcessor
 
     /// <summary>
     /// Awaits a non-generic <see cref="Task" /> short-circuit result and runs
-    /// <paramref name="postInvoke" /> in a <c>finally</c>. Returning this task from
-    /// <see cref="BaseAspect{T}.HandleAsyncShortCircuit" /> ensures the caller's <c>await</c>
-    /// observes <paramref name="postInvoke" /> having completed before resuming, matching the
-    /// contract of the generic <see cref="ProcessFunctionAsync{TK}" /> path.
+    /// <paramref name="postInvoke" /> in a <c>finally</c>. Assigning this task to
+    /// <see cref="AspectContext.ReturnValue" /> inside <see cref="BaseAspect{T}.HandleAsyncShortCircuit" />
+    /// ensures the caller's <c>await</c> observes <paramref name="postInvoke" /> having
+    /// completed before resuming, matching the contract of the generic
+    /// <see cref="ProcessFunctionAsync{TK}" /> path.
     /// </summary>
     /// <param name="task">The non-generic task supplied by a short-circuiting aspect.</param>
     /// <param name="aspectContext">The invocation context passed to <paramref name="postInvoke" />.</param>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # AspectCentral.DispatchProxy
 
-[![Build Status](https://dev.azure.com/jamesconsulting/Aspect%20Central/_apis/build/status/jamesconsultingllc.AspectCentral.DispatchProxy?branchName=master)](https://dev.azure.com/jamesconsulting/Aspect%20Central/_build/latest?definitionId=24&branchName=master)
-![Azure DevOps tests (branch)](https://img.shields.io/azure-devops/tests/jamesconsulting/Aspect%20Central/24/master)
-![Azure DevOps coverage (branch)](https://img.shields.io/azure-devops/coverage/jamesconsulting/Aspect%20Central/24/master)
+[![CI](https://github.com/jamesconsultingllc/AspectCentral.DispatchProxy/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/jamesconsultingllc/AspectCentral.DispatchProxy/actions/workflows/ci.yml)
+[![NuGet](https://img.shields.io/nuget/v/AspectCentral.DispatchProxy.svg)](https://www.nuget.org/packages/AspectCentral.DispatchProxy/)
+[![Downloads](https://img.shields.io/nuget/dt/AspectCentral.DispatchProxy.svg)](https://www.nuget.org/packages/AspectCentral.DispatchProxy/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 > Lightweight, dependency-injection-native **Aspect-Oriented Programming (AOP)** for .NET, built on
 > [`System.Reflection.DispatchProxy`](https://learn.microsoft.com/dotnet/api/system.reflection.dispatchproxy).


### PR DESCRIPTION
## Summary

Three things on one branch:

1. **README badges** — swap the lingering Azure DevOps Pipelines badges (build status, tests, coverage) for the GitHub-native set used by [AspectCentral.Abstractions](https://github.com/jamesconsultingllc/AspectCentral.Abstractions): CI status, NuGet version, NuGet downloads, license. The ADO badges were stale since PR #4 (CI migration).

2. **Production bug fix — non-generic Task short-circuit** (`fix:` commit). `BaseAspect.HandleAsyncShortCircuit` attached `PostInvoke` via `shortCircuitTask.ContinueWith(...)` and discarded the continuation, leaving the proxy returning the original task. A caller's `await proxy.X()` therefore resumed before `PostInvoke` ran — asymmetric with the `Task<T>` path, which uses `ProcessFunctionAsync<TK>` (await + finally) and assigns the wrapper back to `ReturnValue`. Added `BaseAspectAsyncProcessor.ProcessActionAsync` (non-generic mirror) and assigned its returned task back to `aspectContext.ReturnValue` so the caller's await observes `PostInvoke` having completed. Found via a rubber-duck review by GPT-5.5 before opening this PR. `LoggingAspect`/`ProfilingAspect` shipped in this package never short-circuit, so production blast radius is zero today, but any user-written aspect that sets `InvokeMethod=false` and a non-generic `Task` `ReturnValue` (e.g. a caching aspect) would race.

3. **Coverage boost** — push line coverage to **100.00%** and branch to **87.16%**:
   - Add 4 tests for the `IAspectConfigurationProvider` type/factory guards in `AddAspectSupport(IServiceCollection, IAspectConfigurationProvider)` and the fluent `GetOrAddInMemoryProvider` path. `ServiceCollectionExtensions` goes from 89.1% → **100%** line.
   - Add `ShortCircuitAspect` to exercise the InvokeMethod=false / Task short-circuit paths in `BaseAspect.DispatchIntercepted` and `HandleAsyncShortCircuit`. The non-generic Task test uses `Task.Delay(1)` (timer-backed, deterministically pending, not a `Task<VoidTaskResult>` — `Task.CompletedTask` would have routed through the generic branch).
   - Add a `coverlet.runsettings` that excludes Roslyn source-generator output (`obj/.../LoggerMessage.g.cs`) and code-gen attributes (`GeneratedCode`/`CompilerGenerated`/`ExcludeFromCodeCoverage`); wired into the CI test step.

Every class in the library is now 100% line covered.

## Test
\`dotnet test\` → 94 passed / 0 failed (net10.0).